### PR TITLE
feat: add Bun content generator and configurable homepage heatmap

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -196,6 +196,29 @@ Preview the production build:
 bun run preview
 ```
 
+## Creating Content
+
+Create a new blog post:
+
+```sh
+bun run post:new my-first-post
+```
+
+Create a new vibe note:
+
+```sh
+bun run vibe:new today-cloud
+```
+
+Create MDX content:
+
+```sh
+bun run post:new my-interactive-post --mdx
+bun run vibe:new photo-note --mdx
+```
+
+The command argument is the file slug, not the final article title. Blog files are created in `src/content/blog/`; vibe files are created in `src/content/vibe/` with the existing date-prefixed filename convention.
+
 ## Project Structure
 
 ```text

--- a/README.md
+++ b/README.md
@@ -181,6 +181,29 @@ bun run build
 bun run preview
 ```
 
+## 创建内容
+
+创建一篇新的博客文章：
+
+```sh
+bun run post:new my-first-post
+```
+
+创建一条新的 vibe 短记录：
+
+```sh
+bun run vibe:new today-cloud
+```
+
+创建 MDX 内容：
+
+```sh
+bun run post:new my-interactive-post --mdx
+bun run vibe:new photo-note --mdx
+```
+
+命令参数是文件 slug，不是最终文章标题。博客文件会生成到 `src/content/blog/`，vibe 文件会按现有约定生成到 `src/content/vibe/` 并带日期前缀。
+
 ## 项目结构
 
 ```text

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
+    "post:new": "bun scripts/new-content.ts blog",
+    "vibe:new": "bun scripts/new-content.ts vibe",
     "format": "prettier --write .",
     "format:check": "prettier --check ."
   },

--- a/scripts/new-content.ts
+++ b/scripts/new-content.ts
@@ -1,0 +1,163 @@
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+type ContentType = 'blog' | 'vibe';
+type Extension = 'md' | 'mdx';
+
+type ContentTypeConfig = {
+  collectionName: ContentType;
+  directory: string;
+  defaultExtension: Extension;
+  fileName: (slug: string, now: Date) => string;
+  bodyTemplate: (title: string) => string;
+  frontmatterTemplate: (title: string, isoDate: string) => string;
+};
+
+const CONTENT_TYPES = {
+  blog: {
+    collectionName: 'blog',
+    directory: 'src/content/blog',
+    defaultExtension: 'md',
+    fileName: (slug) => slug,
+    bodyTemplate: createBlogBody,
+    frontmatterTemplate: createBlogFrontmatter,
+  },
+  vibe: {
+    collectionName: 'vibe',
+    directory: 'src/content/vibe',
+    defaultExtension: 'md',
+    fileName: (slug, now) => `${formatDatePrefix(now)}-${slug}`,
+    bodyTemplate: createVibeBody,
+    frontmatterTemplate: createVibeFrontmatter,
+  },
+} satisfies Record<ContentType, ContentTypeConfig>;
+
+const args = process.argv.slice(2);
+const contentTypeArg = args[0];
+const filenameArg = args.find((arg, index) => index > 0 && arg !== '--mdx');
+
+if (!isSupportedContentType(contentTypeArg)) {
+  printUnsupportedContentType(contentTypeArg);
+  process.exit(1);
+}
+
+if (filenameArg === undefined) {
+  printMissingFilename();
+  process.exit(1);
+}
+
+const slug = normalizeFilename(filenameArg);
+
+if (!slug) {
+  console.error('Invalid filename.');
+  process.exit(1);
+}
+
+const now = new Date();
+const isoDate = now.toISOString();
+const config = CONTENT_TYPES[contentTypeArg];
+const extension: Extension = args.includes('--mdx') ? 'mdx' : config.defaultExtension;
+const title = createTitle(slug);
+const baseName = config.fileName(slug, now);
+const relativePath = path.join(config.directory, `${baseName}.${extension}`);
+const targetPath = path.resolve(relativePath);
+
+if (existsSync(targetPath)) {
+  console.error(`File already exists: ${relativePath}`);
+  process.exit(1);
+}
+
+mkdirSync(path.dirname(targetPath), { recursive: true });
+writeFileSync(
+  targetPath,
+  `${config.frontmatterTemplate(title, isoDate)}\n\n${config.bodyTemplate(title)}\n`,
+  'utf8',
+);
+
+console.log(`Created new ${config.collectionName} file:`);
+console.log(relativePath);
+
+function isSupportedContentType(value: string | undefined): value is ContentType {
+  return value === 'blog' || value === 'vibe';
+}
+
+function normalizeFilename(value: string): string {
+  return value
+    .trim()
+    .replace(/\.(mdx?|MDX?)$/, '')
+    .replace(/\s+/g, '-')
+    .replace(/[<>:"/\\|?*\u0000-\u001F]/g, '')
+    .replace(/\.+/g, '.')
+    .replace(/^\.+|\.+$/g, '')
+    .replace(/^-+|-+$/g, '');
+}
+
+function createTitle(slug: string): string {
+  return slug
+    .split(/[-_]+/g)
+    .filter(Boolean)
+    .map((part) => {
+      if (!/[A-Za-z]/.test(part)) {
+        return part;
+      }
+
+      return part.charAt(0).toUpperCase() + part.slice(1);
+    })
+    .join(' ');
+}
+
+function formatDatePrefix(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function createBlogFrontmatter(title: string, isoDate: string): string {
+  return `---
+title: "${escapeYamlString(title)}"
+description: ""
+date: "${isoDate}"
+draft: true
+tags: []
+comments: true
+---`;
+}
+
+function createVibeFrontmatter(_title: string, isoDate: string): string {
+  return `---
+date: "${isoDate}"
+draft: true
+type: text
+tags: []
+align: left
+size: md
+---`;
+}
+
+function createBlogBody(title: string): string {
+  return `# ${title}
+
+Start writing here.`;
+}
+
+function createVibeBody(): string {
+  return 'A small note from today.';
+}
+
+function escapeYamlString(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+function printMissingFilename(): void {
+  console.error(`Please provide a filename.
+
+Examples:
+bun run post:new my-first-post
+bun run vibe:new today-cloud`);
+}
+
+function printUnsupportedContentType(contentType: string | undefined): void {
+  console.error(`Unsupported content type: ${contentType ?? ''}
+
+Supported types:
+- blog
+- vibe`);
+}

--- a/scripts/new-content.ts
+++ b/scripts/new-content.ts
@@ -116,16 +116,26 @@ title: "${escapeYamlString(title)}"
 description: ""
 date: "${isoDate}"
 draft: true
+showHeroImage: false
 tags: []
 comments: true
+sidebar:
+  enable: true
+  toc: true
+  relatedPosts: true
 ---`;
 }
 
-function createVibeFrontmatter(_title: string, isoDate: string): string {
+function createVibeFrontmatter(title: string, isoDate: string): string {
   return `---
+title: "${escapeYamlString(title)}"
 date: "${isoDate}"
+updatedDate: "${isoDate}"
 draft: true
 type: text
+mood: ""
+location: ""
+images: []
 tags: []
 align: left
 size: md

--- a/src/components/cards/NavigationCard.astro
+++ b/src/components/cards/NavigationCard.astro
@@ -45,6 +45,7 @@ function withBase(href: string) {
 
 <style>
   .nav-card {
+    width: 100%;
     padding: 20px 0;
     border: 0;
     background: transparent;
@@ -53,6 +54,7 @@ function withBase(href: string) {
 
   nav {
     display: grid;
+    width: 100%;
     gap: 8px;
   }
 
@@ -115,9 +117,10 @@ function withBase(href: string) {
     }
 
     .nav-item {
-      grid-template-columns: 24px minmax(0, max-content);
+      width: 100%;
+      grid-template-columns: 24px minmax(0, 1fr);
       gap: 10px;
-      justify-content: center;
+      justify-content: start;
       min-width: 0;
       padding: 9px 0;
     }
@@ -129,7 +132,7 @@ function withBase(href: string) {
 
     strong {
       max-width: 100%;
-      text-align: center;
+      text-align: left;
     }
 
     small,

--- a/src/components/widgets/BlogHeatmap.astro
+++ b/src/components/widgets/BlogHeatmap.astro
@@ -8,11 +8,12 @@ import {
 } from '../../utils/blog-heatmap';
 
 interface Props {
-  weeks?: 12 | 24;
+  weeks?: number;
   showLatest?: boolean;
   latestCount?: number;
   excludeDraft?: boolean;
   dateArchiveBaseHref?: string;
+  startDate?: Date | string | null;
 }
 
 const {
@@ -21,9 +22,13 @@ const {
   latestCount = 1,
   excludeDraft = true,
   dateArchiveBaseHref,
+  startDate,
 } = Astro.props;
 const posts = await getCollection('blog', ({ data }) => !excludeDraft || !data.draft);
-const heatmap = createRecentBlogHeatmap(posts, weeks, latestCount);
+const heatmap = createRecentBlogHeatmap(posts, weeks, latestCount, startDate);
+const heatmapLabel = startDate
+  ? `Writing activity since ${heatmap.startDate}`
+  : `Recent ${heatmap.weeks} weeks writing activity`;
 const formatDate = new Intl.DateTimeFormat('en', {
   month: 'short',
   day: 'numeric',
@@ -91,7 +96,7 @@ function getTooltipPosts(posts: HeatmapPost[]) {
     )
   }
 
-  <div class="rhythm-grid" aria-label={`Recent ${heatmap.weeks} weeks writing activity`}>
+  <div class="rhythm-grid" aria-label={heatmapLabel}>
     <div class="weekday-column" aria-hidden="true">
       <span>Mon</span>
       <span>Wed</span>

--- a/src/components/widgets/BlogHeatmap.astro
+++ b/src/components/widgets/BlogHeatmap.astro
@@ -440,18 +440,26 @@ function getTooltipPosts(posts: HeatmapPost[]) {
     }
 
     .rhythm-grid {
-      --cell-size: clamp(6px, 2.08vw, 8px);
-      --cell-gap: 2px;
+      --cell-gap: 2.5px;
       grid-template-columns: 22px minmax(0, 1fr);
       overflow: hidden;
       width: 100%;
     }
 
     .heatmap-cells {
-      width: min(
-        100%,
-        calc((var(--cell-size) * var(--week-count)) + (var(--cell-gap) * (var(--week-count) - 1)))
-      );
+      grid-template-rows: repeat(7, auto);
+      grid-auto-columns: minmax(0, 1fr);
+      width: 100%;
+      max-width: 360px;
+    }
+
+    .heatmap-cells .heatmap-cell,
+    .heatmap-cells .cell-link {
+      width: 100%;
+      height: auto;
+      min-width: 0;
+      min-height: 0;
+      aspect-ratio: 1;
     }
 
     .weekday-column {

--- a/src/config/site.toml
+++ b/src/config/site.toml
@@ -92,6 +92,11 @@ image = "/images/logo-cat.png"
 
 [config.home.latest]
 count = 1
+heatmapWeeks = 24
+showHeatmapLatest = true
+excludeDraft = true
+startDate = ""
+dateArchiveBaseHref = ""
 
 [[config.home.navigation]]
 icon = "compass"

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -136,9 +136,21 @@ const siteConfig = defineCollection({
       latest: z
         .object({
           count: z.number().int().positive().default(1),
+          heatmapWeeks: z.number().int().positive().default(24),
+          showHeatmapLatest: z.boolean().optional().default(true),
+          excludeDraft: z.boolean().optional().default(true),
+          startDate: z.string().optional().default(''),
+          dateArchiveBaseHref: z.string().optional().default(''),
         })
         .optional()
-        .default({ count: 1 }),
+        .default({
+          count: 1,
+          heatmapWeeks: 24,
+          showHeatmapLatest: true,
+          excludeDraft: true,
+          startDate: '',
+          dateArchiveBaseHref: '',
+        }),
       navigation: z.array(navigationItemSchema),
       connect: z.array(linkSchema.required({ icon: true })),
       doing: z.array(

--- a/src/content/about.mdx
+++ b/src/content/about.mdx
@@ -1,14 +1,14 @@
 ---
 title: '关于 navfolio'
 description: '一个安静的个人发布起点，用于整合链接、笔记、写作与个人资料内容。'
-date: '2026-05-01'
+date: '2026-05-01T00:00:00+08:00'
 draft: false
 showHeroImage: false
-comments: false
 tags:
   - About
   - Navfolio
   - Personal Site
+comments: false
 sidebar:
   enable: false
   toc: false

--- a/src/content/blog/add-comment-system-to-navfolio.md
+++ b/src/content/blog/add-comment-system-to-navfolio.md
@@ -1,15 +1,19 @@
 ---
 title: '为 Navfolio 接入可配置评论系统'
 description: '记录一次为 Astro 博客主题添加 giscus、utterances 和 Waline 评论系统的过程。'
-date: '2026-05-20'
-showHeroImage: false
-heroImage: '/src/assets/figure/comment-hero.png'
+date: '2026-05-20T00:00:00+08:00'
 draft: false
-comments: true
+heroImage: '/src/assets/figure/comment-hero.png'
+showHeroImage: false
 tags:
   - Astro
   - Navfolio
   - Comment
+comments: true
+sidebar:
+  enable: true
+  toc: true
+  relatedPosts: true
 ---
 
 一个安静的个人博客不一定需要评论区，但它需要给读者留下继续说话的可能。Navfolio 的评论系统因此做成了可配置模块：默认服务于文章页，又允许站点维护者按自己的内容节奏关闭它。

--- a/src/content/blog/first-post.md
+++ b/src/content/blog/first-post.md
@@ -1,14 +1,19 @@
 ---
 title: '荷塘月色'
 description: '一篇以夏夜荷塘为中心的中文散文改写：月光、荷叶、微风与独行的心绪，在静夜里缓慢铺开。'
-date: '2026-05-18'
+date: '2026-05-18T00:00:00+08:00'
+draft: false
 heroImage: '/src/assets/figure/lotus.png'
 showHeroImage: true
-comments: true
 tags:
   - '散文'
   - '中文'
   - '荷塘月色'
+comments: true
+sidebar:
+  enable: true
+  toc: true
+  relatedPosts: true
 ---
 
 这几天心里颇不宁静。夜里坐在屋中，总觉得四周的空气有些沉，像有许多细小的念头堆在窗前，挥不开，也说不清。妻在屋里拍着孩子入睡，轻轻的声响一下一下落下去，院子渐渐静了。我披了衣衫，推门出去，想着到荷塘边走走。

--- a/src/content/blog/friend-link-card.mdx
+++ b/src/content/blog/friend-link-card.mdx
@@ -1,15 +1,20 @@
 ---
 title: '使用 MDX 完成友链卡片的展示'
 description: '在文章中优雅展示友链信息的轻量卡片组件'
-date: '2026-05-19'
+date: '2026-05-19T00:00:00+08:00'
+draft: false
 heroImage: '/src/assets/figure/sample-bg.png'
 showHeroImage: true
-comments: true
 tags:
   - 'MDX'
   - 'Astro'
   - 'Components'
   - 'FriendLink'
+comments: true
+sidebar:
+  enable: true
+  toc: true
+  relatedPosts: true
 ---
 
 这篇文章介绍如何在 MDX 内容中使用 FriendLinkCard 组件，快速展示站点名称、链接、头像和简介。

--- a/src/content/blog/markdown-style-guide.md
+++ b/src/content/blog/markdown-style-guide.md
@@ -1,13 +1,18 @@
 ---
 title: 'Markdown 语法渲染示例'
 description: '这是一篇用于展示 Astro 中常见 Markdown 语法渲染效果的中文示例文章。'
-date: '2026-05-19'
+date: '2026-05-19T00:00:00+08:00'
+draft: false
 heroImage: '/src/assets/figure/blog-sample-picture.png'
 showHeroImage: true
-comments: true
 tags:
   - 'Markdown'
   - '教程'
+comments: true
+sidebar:
+  enable: true
+  toc: true
+  relatedPosts: true
 ---
 
 这篇文章用于集中展示常见 Markdown 语法在 Astro 中的渲染效果，便于你写作时快速对照。

--- a/src/content/blog/second-post.md
+++ b/src/content/blog/second-post.md
@@ -1,14 +1,19 @@
 ---
 title: 'Moonlight over the Lotus Pond'
 description: 'An English rendering of a quiet summer-night walk by a lotus pond, where moonlight softens the world and solitude becomes briefly spacious.'
-date: '2026-05-18'
+date: '2026-05-18T00:00:00+08:00'
+draft: false
 heroImage: '/src/assets/figure/lotus.png'
 showHeroImage: true
-comments: true
 tags:
   - 'Essay'
   - 'English'
   - 'Moonlight'
+comments: true
+sidebar:
+  enable: true
+  toc: true
+  relatedPosts: true
 ---
 
 For several days my mind had not been at ease. The room felt too close, and the small sounds of the evening seemed to gather around me without meaning. My wife was inside, coaxing the child to sleep. The courtyard had settled into silence. I put on a light coat and stepped out, thinking I might walk by the lotus pond for a while.

--- a/src/content/blog/third-post.md
+++ b/src/content/blog/third-post.md
@@ -1,14 +1,19 @@
 ---
 title: '蓮池の月明かり'
 description: '夏の夜、蓮池のほとりをひとり歩く心のゆらぎを、日本語で静かに綴った散文。'
-date: '2026-05-18'
+date: '2026-05-18T00:00:00+08:00'
+draft: false
 heroImage: '/src/assets/figure/lotus.png'
 showHeroImage: true
-comments: true
 tags:
   - '随筆'
   - '日本語'
   - '月明かり'
+comments: true
+sidebar:
+  enable: true
+  toc: true
+  relatedPosts: true
 ---
 
 ここ数日、心がどうにも落ち着かなかった。部屋の中に座っていても、空気が少し重く感じられ、考えごとばかりが窓辺にたまっていくようだった。妻は奥で子どもを寝かしつけている。庭はしだいに静まり、夜の気配だけが残った。私は薄い上着を羽織り、蓮池の方へ歩いてみることにした。

--- a/src/content/blog/toml-site-config-guide.md
+++ b/src/content/blog/toml-site-config-guide.md
@@ -2,14 +2,14 @@
 title: '用 TOML 管理站点信息'
 description: '了解 navfolio 如何把站点标题、个人资料、导航入口和首页模块集中到 src/config/site.toml 中维护。'
 date: '2026-05-19T18:00:00+08:00'
+draft: false
 heroImage: '/src/assets/figure/toml.png'
 showHeroImage: true
-draft: false
-comments: true
 tags:
   - Astro
   - TOML
   - Configuration
+comments: true
 sidebar:
   enable: true
   toc: true

--- a/src/content/blog/vibe-content-guide.mdx
+++ b/src/content/blog/vibe-content-guide.mdx
@@ -2,14 +2,14 @@
 title: 'Vibe 内容格式使用指南'
 description: '了解 navfolio 的 vibe 页面如何用 Markdown 管理生活碎片、开发札记、图片片段和轻量引用。'
 date: '2026-05-20T16:40:00+08:00'
+draft: false
 heroImage: '/src/assets/figure/vibe-hero.png'
 showHeroImage: false
-draft: false
-comments: true
 tags:
   - Astro
   - Vibe
   - Content
+comments: true
 sidebar:
   enable: true
   toc: true

--- a/src/content/projects/astro-navfolio.mdx
+++ b/src/content/projects/astro-navfolio.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Astro Navfolio'
 description: 'An Astro starter for a quiet personal publishing space: homepage, blog, project notes, and digital-garden structure in one maintainable site.'
-date: '2026-05-18'
+date: '2026-05-18T00:00:00+08:00'
 draft: false
 showHeroImage: true
 tags:
@@ -9,8 +9,11 @@ tags:
   - Starter
   - Digital Garden
   - Portfolio
+comments: false
 sidebar:
   enable: false
+  toc: false
+  relatedPosts: false
 ---
 
 Astro Navfolio 是一个为个人站点准备的开源 starter。它不是传统的单页简历，也不是只展示文章列表的博客模板，而是把个人介绍、常用入口、文章归档、项目文档和轻量状态组件组织到同一个静态站点里。

--- a/src/content/projects/index.mdx
+++ b/src/content/projects/index.mdx
@@ -1,11 +1,15 @@
 ---
 title: 'Projects'
 description: 'Repository notes and product writeups for small tools, site systems, and publishing experiments.'
-date: '2026-05-18'
+date: '2026-05-18T00:00:00+08:00'
 draft: false
 showHeroImage: true
+tags: []
+comments: false
 sidebar:
   enable: false
+  toc: false
+  relatedPosts: false
 ---
 
 这个分区用于收录正在开发、已经发布，或在设计与实现层面值得记录的项目。每条内容更像一份项目简报：说明项目为什么存在、解决什么问题、当前具备哪些能力，以及后续如何继续演进。

--- a/src/content/vibe/2026-05-19-font-loading.md
+++ b/src/content/vibe/2026-05-19-font-loading.md
@@ -1,7 +1,12 @@
 ---
-date: 2026-05-19
+title: 'font loading'
+date: '2026-05-19T00:00:00+08:00'
+updatedDate: '2026-05-19T00:00:00+08:00'
+draft: false
 type: text
 mood: quiet
+location: ''
+images: []
 tags: [dev, daily]
 align: left
 size: md

--- a/src/content/vibe/2026-05-20-rainy-night.md
+++ b/src/content/vibe/2026-05-20-rainy-night.md
@@ -1,5 +1,8 @@
 ---
-date: 2026-05-20
+title: 'rainy night'
+date: '2026-05-20T00:00:00+08:00'
+updatedDate: '2026-05-20T00:00:00+08:00'
+draft: false
 type: photo
 mood: rainy
 location: Tokyo

--- a/src/content/vibe/2026-05-21-small-thought.md
+++ b/src/content/vibe/2026-05-21-small-thought.md
@@ -1,8 +1,12 @@
 ---
 title: after work
-date: 2026-05-21
+date: '2026-05-21T00:00:00+08:00'
+updatedDate: '2026-05-21T00:00:00+08:00'
+draft: false
 type: mixed
 mood: after work
+location: ''
+images: []
 tags: [blog, idea]
 align: center
 size: sm

--- a/src/content/vibe/2026-05-22-window-light.md
+++ b/src/content/vibe/2026-05-22-window-light.md
@@ -1,9 +1,12 @@
 ---
 title: window light
-date: 2026-05-22
+date: '2026-05-22T00:00:00+08:00'
+updatedDate: '2026-05-22T00:00:00+08:00'
+draft: false
 type: text
 mood: soft focus
 location: Desk
+images: []
 tags: [daily, writing]
 align: left
 size: md

--- a/src/content/vibe/2026-05-23-route-switching.md
+++ b/src/content/vibe/2026-05-23-route-switching.md
@@ -1,8 +1,12 @@
 ---
 title: route switching
-date: 2026-05-23
+date: '2026-05-23T00:00:00+08:00'
+updatedDate: '2026-05-23T00:00:00+08:00'
+draft: false
 type: text
 mood: tiny motion
+location: ''
+images: []
 tags: [dev, astro]
 align: right
 size: sm

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -19,3 +19,4 @@ export type HomeConnectItem = SiteConfig['home']['connect'][number];
 export type HomeDoingItem = SiteConfig['home']['doing'][number];
 export type HomeIntro = SiteConfig['home']['intro'];
 export type HomeQuote = SiteConfig['home']['quote'];
+export type HomeLatest = SiteConfig['home']['latest'];

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -23,7 +23,14 @@ const { home, profile, site } = await getSiteConfig();
     </Fragment>
 
     <Fragment slot="activity">
-      <BlogHeatmap weeks={24} latestCount={home.latest.count} />
+      <BlogHeatmap
+        weeks={home.latest.heatmapWeeks}
+        showLatest={home.latest.showHeatmapLatest}
+        latestCount={home.latest.count}
+        excludeDraft={home.latest.excludeDraft}
+        startDate={home.latest.startDate || null}
+        dateArchiveBaseHref={home.latest.dateArchiveBaseHref || undefined}
+      />
     </Fragment>
 
     <Fragment slot="links">

--- a/src/utils/blog-heatmap.ts
+++ b/src/utils/blog-heatmap.ts
@@ -17,6 +17,7 @@ export interface HeatmapDay {
 export interface HeatmapWindow {
   days: HeatmapDay[];
   weeks: number;
+  startDate: string;
   totalPosts: number;
   activeDays: number;
   currentStreak: number;
@@ -30,6 +31,10 @@ export interface LatestPost {
 }
 
 type BlogPost = CollectionEntry<'blog'>;
+type HeatmapStartDate = Date | string | null | undefined;
+
+const DAYS_IN_WEEK = 7;
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
 
 export function getDateKey(date: Date): string {
   const year = date.getFullYear();
@@ -66,6 +71,19 @@ function getStartOfWeek(date: Date) {
   return start;
 }
 
+function getConfiguredStartDate(startDate: HeatmapStartDate) {
+  if (!startDate) return null;
+
+  const date = startDate instanceof Date ? new Date(startDate) : new Date(startDate);
+
+  if (Number.isNaN(date.valueOf())) {
+    return null;
+  }
+
+  date.setHours(0, 0, 0, 0);
+  return date;
+}
+
 function getPostsByDate(posts: BlogPost[]) {
   const postsByDate = new Map<string, HeatmapPost[]>();
 
@@ -86,19 +104,31 @@ export function createRecentBlogHeatmap(
   posts: BlogPost[],
   weeks = 12,
   latestCount = 1,
+  startDate?: HeatmapStartDate,
 ): HeatmapWindow {
-  const safeWeeks = weeks === 24 ? 24 : 12;
   const today = new Date();
   today.setHours(0, 0, 0, 0);
 
   const currentWeekStart = getStartOfWeek(today);
-  const start = new Date(currentWeekStart);
-  start.setDate(start.getDate() - (safeWeeks - 1) * 7);
+  const configuredStartDate = getConfiguredStartDate(startDate);
+  const start = configuredStartDate
+    ? getStartOfWeek(configuredStartDate > today ? today : configuredStartDate)
+    : new Date(currentWeekStart);
+  const safeWeeks = configuredStartDate
+    ? Math.max(
+        1,
+        Math.floor((currentWeekStart.valueOf() - start.valueOf()) / (DAYS_IN_WEEK * DAY_IN_MS)) + 1,
+      )
+    : Math.max(1, Math.floor(weeks));
+
+  if (!configuredStartDate) {
+    start.setDate(start.getDate() - (safeWeeks - 1) * DAYS_IN_WEEK);
+  }
 
   const postsByDate = getPostsByDate(posts);
   const days: HeatmapDay[] = [];
 
-  for (let index = 0; index < safeWeeks * 7; index += 1) {
+  for (let index = 0; index < safeWeeks * DAYS_IN_WEEK; index += 1) {
     const date = new Date(start);
     date.setDate(start.getDate() + index);
     const key = getDateKey(date);
@@ -126,6 +156,7 @@ export function createRecentBlogHeatmap(
   return {
     days,
     weeks: safeWeeks,
+    startDate: getDateKey(start),
     totalPosts: days.reduce((total, day) => total + day.count, 0),
     activeDays: days.filter((day) => day.count > 0).length,
     currentStreak,


### PR DESCRIPTION
## Summary

- Add a shared Bun content generator for blog posts and vibe notes.
- Add `post:new` and `vibe:new` scripts with Markdown/MDX support.
- Complete frontmatter metadata across existing `src/content` entries.
- Expose homepage heatmap settings through `[config.home.latest]` in `site.toml`.
- Add configurable heatmap start date support while preserving the default recent-weeks behavior.
- Improve mobile homepage nav-card and heatmap width behavior.

## Details

- `bun run post:new <filename>` creates blog content under `src/content/blog/`.
- `bun run vibe:new <filename>` creates date-prefixed vibe content under `src/content/vibe/`.
- Generated frontmatter now follows the current Astro content schemas more completely.
- `startDate = ""` keeps the heatmap using recent weeks.
- Setting `startDate = "YYYY-MM-DD"` makes the heatmap start from that date’s week.

## Verification

- `bun run format:check`
- `bun run build`