### PR TITLE
Add zoomable article imagesfeat: add zoomable article images

### DIFF
--- a/src/components/mdx/ZoomableImage.astro
+++ b/src/components/mdx/ZoomableImage.astro
@@ -1,0 +1,279 @@
+---
+import { ZoomIn } from 'lucide-astro';
+import type { ImageMetadata } from 'astro';
+import type { HTMLAttributes } from 'astro/types';
+
+type Props = Omit<HTMLAttributes<'img'>, 'src'> & {
+  className?: string;
+  src?: string | ImageMetadata;
+};
+
+const { class: classAttr, className, alt = '', src, width, height, ...imageProps } = Astro.props;
+const imageMetadata = src && typeof src === 'object' && 'src' in src ? src : undefined;
+const resolvedSrc = imageMetadata ? imageMetadata.src : src;
+const resolvedWidth = width ?? imageMetadata?.width;
+const resolvedHeight = height ?? imageMetadata?.height;
+const imageClass = [classAttr, className].filter(Boolean).join(' ');
+const altText = typeof alt === 'string' ? alt : '';
+const previewLabel = altText.trim() ? `Open image preview: ${altText}` : 'Open image preview';
+const hasImageSource = resolvedSrc !== undefined && resolvedSrc !== null;
+---
+
+{
+  hasImageSource && (
+    <span class="zoomable-image" data-zoomable-image data-preview-label={previewLabel}>
+      <img
+        {...imageProps}
+        src={resolvedSrc}
+        alt={alt}
+        width={resolvedWidth}
+        height={resolvedHeight}
+        class={imageClass || undefined}
+        data-zoomable-image-target
+      />
+      <span class="zoomable-image__veil" aria-hidden="true">
+        <span class="zoomable-image__icon">
+          <ZoomIn size={20} strokeWidth={1.8} />
+        </span>
+      </span>
+    </span>
+  )
+}
+
+<script>
+  import { initZoomableImages } from '../../utils/zoomable-images';
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initZoomableImages, { once: true });
+  } else {
+    initZoomableImages();
+  }
+</script>
+
+<style>
+  :global(.zoomable-image) {
+    position: relative;
+    display: block;
+    width: fit-content;
+    max-width: 100%;
+    margin: 30px auto;
+    overflow: hidden;
+    border: 1px solid var(--paper-line);
+    border-radius: 8px;
+    background: var(--paper-surface-muted);
+    cursor: pointer;
+  }
+
+  :global(.zoomable-image:focus-visible) {
+    outline: 2px solid color-mix(in srgb, var(--paper-accent) 36%, transparent);
+    outline-offset: 4px;
+  }
+
+  :global(.zoomable-image img) {
+    display: block;
+    max-width: 100%;
+    height: auto;
+  }
+
+  :global(.zoomable-image__veil) {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    background: color-mix(in srgb, var(--paper-ink) 28%, transparent);
+    opacity: 0;
+    transition: opacity 160ms ease;
+    pointer-events: none;
+  }
+
+  :global(.zoomable-image__icon) {
+    display: grid;
+    width: 42px;
+    height: 42px;
+    place-items: center;
+    border: 1px solid color-mix(in srgb, var(--paper-surface) 72%, transparent);
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--paper-surface) 86%, transparent);
+    color: var(--paper-ink);
+    box-shadow: 0 10px 26px color-mix(in srgb, var(--paper-ink) 12%, transparent);
+    transform: translateY(2px) scale(0.98);
+    transition:
+      opacity 160ms ease,
+      transform 160ms ease;
+  }
+
+  :global(.zoomable-image:hover .zoomable-image__veil),
+  :global(.zoomable-image:focus-visible .zoomable-image__veil) {
+    opacity: 1;
+  }
+
+  :global(.zoomable-image:hover .zoomable-image__icon),
+  :global(.zoomable-image:focus-visible .zoomable-image__icon) {
+    transform: translateY(0) scale(1);
+  }
+
+  :global(.article-content a .zoomable-image) {
+    cursor: pointer;
+  }
+
+  :global(.article-content a .zoomable-image__veil) {
+    display: none;
+  }
+
+  :global(.article-content > p:has(> img):not(:has(a[href]))) {
+    position: relative;
+    width: fit-content;
+    max-width: 100%;
+    margin: 30px auto;
+    overflow: hidden;
+    border: 1px solid var(--paper-line);
+    border-radius: 8px;
+    background: var(--paper-surface-muted);
+    cursor: pointer;
+  }
+
+  :global(.article-content figure:has(> img):not(:has(a[href]))) {
+    position: relative;
+    cursor: pointer;
+  }
+
+  :global(.article-content > p:has(> img):not(:has(a[href])) > img),
+  :global(.article-content figure:has(> img):not(:has(a[href])) > img) {
+    display: block;
+    max-width: 100%;
+    height: auto;
+  }
+
+  :global(.article-content > p:has(> img):not(:has(a[href]))::before),
+  :global(.article-content figure:has(> img):not(:has(a[href]))::before) {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    background: color-mix(in srgb, var(--paper-ink) 28%, transparent);
+    opacity: 0;
+    transition: opacity 160ms ease;
+    pointer-events: none;
+    content: '';
+  }
+
+  :global(.article-content > p:has(> img):not(:has(a[href]))::after),
+  :global(.article-content figure:has(> img):not(:has(a[href]))::after) {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    z-index: 2;
+    display: grid;
+    width: 42px;
+    height: 42px;
+    place-items: center;
+    border: 1px solid color-mix(in srgb, var(--paper-surface) 72%, transparent);
+    border-radius: 999px;
+    background-color: color-mix(in srgb, var(--paper-surface) 86%, transparent);
+    background-image: url("data:image/svg+xml,%3Csvg width='20' height='20' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' stroke='%23343c35' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.8'%3E%3Ccircle cx='11' cy='11' r='8'/%3E%3Cpath d='m21 21-4.3-4.3M11 8v6M8 11h6'/%3E%3C/g%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: center;
+    box-shadow: 0 10px 26px color-mix(in srgb, var(--paper-ink) 12%, transparent);
+    opacity: 0;
+    transform: translate(-50%, calc(-50% + 2px)) scale(0.98);
+    transition:
+      opacity 160ms ease,
+      transform 160ms ease;
+    pointer-events: none;
+    content: '';
+  }
+
+  :global(.article-content > p:has(> img):not(:has(a[href])):hover::before),
+  :global(.article-content figure:has(> img):not(:has(a[href])):hover::before),
+  :global(.article-content > p:has(> img):not(:has(a[href])):focus-within::before),
+  :global(.article-content figure:has(> img):not(:has(a[href])):focus-within::before),
+  :global(.article-content > p:has(> img):not(:has(a[href])):hover::after),
+  :global(.article-content figure:has(> img):not(:has(a[href])):hover::after),
+  :global(.article-content > p:has(> img):not(:has(a[href])):focus-within::after),
+  :global(.article-content figure:has(> img):not(:has(a[href])):focus-within::after) {
+    opacity: 1;
+  }
+
+  :global(.article-content > p:has(> img):not(:has(a[href])):hover::after),
+  :global(.article-content figure:has(> img):not(:has(a[href])):hover::after),
+  :global(.article-content > p:has(> img):not(:has(a[href])):focus-within::after),
+  :global(.article-content figure:has(> img):not(:has(a[href])):focus-within::after) {
+    transform: translate(-50%, -50%) scale(1);
+  }
+
+  :global(.zoomable-image-lightbox) {
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+    display: grid;
+    place-items: center;
+    padding: 28px;
+    background: color-mix(in srgb, var(--paper-ink) 72%, transparent);
+    opacity: 0;
+    visibility: hidden;
+    transition:
+      opacity 180ms ease,
+      visibility 180ms ease;
+  }
+
+  :global(.zoomable-image-lightbox.is-open) {
+    opacity: 1;
+    visibility: visible;
+  }
+
+  :global(.zoomable-image-lightbox__image) {
+    display: block;
+    max-width: min(100%, 1180px);
+    max-height: 88vh;
+    object-fit: contain;
+    border-radius: 8px;
+    box-shadow: 0 18px 56px color-mix(in srgb, #000 32%, transparent);
+  }
+
+  :global(.zoomable-image-lightbox__close) {
+    position: fixed;
+    top: max(18px, env(safe-area-inset-top));
+    right: max(18px, env(safe-area-inset-right));
+    display: grid;
+    width: 42px;
+    height: 42px;
+    place-items: center;
+    border: 1px solid color-mix(in srgb, var(--paper-surface) 34%, transparent);
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--paper-surface) 90%, transparent);
+    color: var(--paper-ink);
+    cursor: pointer;
+  }
+
+  :global(.zoomable-image-lightbox__close:focus-visible) {
+    outline: 2px solid color-mix(in srgb, var(--paper-accent) 46%, transparent);
+    outline-offset: 3px;
+  }
+
+  @media (hover: none) {
+    :global(.zoomable-image__veil) {
+      display: none;
+    }
+
+    :global(.article-content > p:has(> img):not(:has(a[href]))::before),
+    :global(.article-content > p:has(> img):not(:has(a[href]))::after),
+    :global(.article-content figure:has(> img):not(:has(a[href]))::before),
+    :global(.article-content figure:has(> img):not(:has(a[href]))::after) {
+      display: none;
+    }
+  }
+
+  @media (max-width: 640px) {
+    :global(.zoomable-image) {
+      width: 100%;
+      margin: 24px 0;
+    }
+
+    :global(.zoomable-image-lightbox) {
+      padding: 16px;
+    }
+
+    :global(.zoomable-image-lightbox__image) {
+      max-height: 82vh;
+    }
+  }
+</style>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -1,6 +1,7 @@
 ---
 import { type CollectionEntry, getCollection, render } from 'astro:content';
 import BlogArticle from '../../layouts/BlogArticle.astro';
+import ZoomableImage from '../../components/mdx/ZoomableImage.astro';
 
 export async function getStaticPaths() {
   const posts = await getCollection('blog');
@@ -16,5 +17,6 @@ const { Content, headings } = await render(post);
 ---
 
 <BlogArticle post={post} headings={headings}>
-  <Content />
+  <Content components={{ img: ZoomableImage }} />
+  <ZoomableImage />
 </BlogArticle>

--- a/src/utils/zoomable-images.ts
+++ b/src/utils/zoomable-images.ts
@@ -1,0 +1,143 @@
+declare global {
+  interface Window {
+    __navfolioZoomableImagesReady?: boolean;
+  }
+}
+
+type LightboxElements = {
+  root: HTMLDivElement;
+  image: HTMLImageElement;
+  closeButton: HTMLButtonElement;
+};
+
+let lightboxElements: LightboxElements | undefined;
+let previousBodyOverflow = '';
+
+const isPlainMarkdownImage = (target: HTMLImageElement) =>
+  Boolean(target.closest('.article-content')) &&
+  !target.closest('[data-zoomable-image]') &&
+  !target.closest('a[href]') &&
+  (target.parentElement?.matches('.article-content > p, .article-content figure') ?? false);
+
+const getZoomTarget = (target: EventTarget | null): HTMLImageElement | undefined => {
+  if (!(target instanceof Element)) {
+    return undefined;
+  }
+
+  const wrappedImage = target
+    .closest('[data-zoomable-image]')
+    ?.querySelector('[data-zoomable-image-target]');
+
+  if (wrappedImage instanceof HTMLImageElement && !wrappedImage.closest('a[href]')) {
+    return wrappedImage;
+  }
+
+  if (target instanceof HTMLImageElement && isPlainMarkdownImage(target)) {
+    return target;
+  }
+
+  return undefined;
+};
+
+const closePreview = () => {
+  if (!lightboxElements) {
+    return;
+  }
+
+  lightboxElements.root.classList.remove('is-open');
+  lightboxElements.root.setAttribute('aria-hidden', 'true');
+  document.body.style.overflow = previousBodyOverflow;
+  lightboxElements.image.removeAttribute('src');
+  lightboxElements.image.alt = '';
+  lightboxElements.image.removeAttribute('title');
+};
+
+const createLightbox = (): LightboxElements => {
+  const root = document.createElement('div');
+  root.className = 'zoomable-image-lightbox';
+  root.setAttribute('aria-hidden', 'true');
+  root.innerHTML = `
+    <button class="zoomable-image-lightbox__close" type="button" aria-label="Close image preview">
+      <svg aria-hidden="true" viewBox="0 0 24 24" width="22" height="22">
+        <path d="M18 6 6 18M6 6l12 12" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8"></path>
+      </svg>
+    </button>
+    <img class="zoomable-image-lightbox__image" alt="" />
+  `;
+  document.body.append(root);
+
+  const image = root.querySelector('.zoomable-image-lightbox__image');
+  const closeButton = root.querySelector('.zoomable-image-lightbox__close');
+
+  if (!(image instanceof HTMLImageElement) || !(closeButton instanceof HTMLButtonElement)) {
+    throw new Error('Failed to initialize zoomable image lightbox.');
+  }
+
+  root.addEventListener('click', (event) => {
+    if (event.target === root) {
+      closePreview();
+    }
+  });
+
+  closeButton.addEventListener('click', closePreview);
+
+  return { root, image, closeButton };
+};
+
+const getLightbox = (): LightboxElements => {
+  lightboxElements ??= createLightbox();
+  return lightboxElements;
+};
+
+const openPreview = (sourceImage: HTMLImageElement) => {
+  const { root, image, closeButton } = getLightbox();
+
+  previousBodyOverflow = document.body.style.overflow;
+  image.src = sourceImage.currentSrc || sourceImage.src;
+  image.alt = sourceImage.alt || '';
+
+  if (sourceImage.title) {
+    image.title = sourceImage.title;
+  } else {
+    image.removeAttribute('title');
+  }
+
+  document.body.style.overflow = 'hidden';
+  root.classList.add('is-open');
+  root.setAttribute('aria-hidden', 'false');
+  closeButton.focus({ preventScroll: true });
+};
+
+export const initZoomableImages = () => {
+  if (window.__navfolioZoomableImagesReady) {
+    return;
+  }
+
+  window.__navfolioZoomableImagesReady = true;
+
+  document.addEventListener('click', (event) => {
+    const image = getZoomTarget(event.target);
+
+    if (image) {
+      openPreview(image);
+    }
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && lightboxElements?.root.classList.contains('is-open')) {
+      closePreview();
+      return;
+    }
+
+    const image = getZoomTarget(event.target);
+
+    if (!image || (event.key !== 'Enter' && event.key !== ' ')) {
+      return;
+    }
+
+    event.preventDefault();
+    openPreview(image);
+  });
+};
+
+export {};


### PR DESCRIPTION
## Summary

Adds a zoomable image experience for Markdown/MDX images rendered inside blog article bodies.

## What Changed

- Added a `ZoomableImage` Astro component for MDX-rendered `img` elements.
- Added a typed `src/utils/zoomable-images.ts` client utility for delegated image click handling and lazy lightbox creation.
- Scoped enhancement to blog article content so site chrome, hero images, related post thumbnails, linked images, and MDX custom image components keep existing behavior.
- Preserved original image attributes such as `src`, `alt`, `title`, `width`, `height`, `class`, `loading`, and `decoding`.

## Validation

- `bun run format:check`
- `bun run build`
- Focused TypeScript check for `src/utils/zoomable-images.ts`

## Notes

A full `tsc --noEmit` still reports pre-existing Zod default typing errors in `src/content.config.ts`, unrelated to this change.