### PR TITLE
feat(#20): add expressive code to beautify code blocks

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,9 +2,11 @@
 
 import mdx from '@astrojs/mdx';
 import sitemap from '@astrojs/sitemap';
-import { defineConfig, fontProviders } from 'astro/config';
+import { defineConfig } from 'astro/config';
 
 import tailwindcss from '@tailwindcss/vite';
+
+import expressiveCode from 'astro-expressive-code';
 
 const isGitHubActions = process.env.GITHUB_ACTIONS === 'true';
 const customSite = process.env.SITE_URL;
@@ -31,7 +33,7 @@ const resolvedBase =
 export default defineConfig({
   site: resolvedSite,
   base: resolvedBase,
-  integrations: [mdx(), sitemap()],
+  integrations: [expressiveCode(), mdx(), sitemap()],
 
   vite: {
     plugins: [tailwindcss()],

--- a/bun.lock
+++ b/bun.lock
@@ -8,11 +8,15 @@
         "@astrojs/mdx": "^5.0.6",
         "@astrojs/rss": "^4.0.18",
         "@astrojs/sitemap": "^3.7.2",
+        "@expressive-code/plugin-collapsible-sections": "^0.42.0",
+        "@expressive-code/plugin-line-numbers": "^0.42.0",
         "@fontsource/maple-mono": "^5.2.6",
         "@tailwindcss/vite": "^4.3.0",
         "astro": "^6.3.5",
+        "astro-expressive-code": "^0.42.0",
         "lucide-astro": "^0.556.0",
         "sharp": "^0.34.5",
+        "smol-toml": "^1.6.1",
         "tailwindcss": "^4.3.0",
       },
       "devDependencies": {
@@ -52,6 +56,8 @@
     "@clack/core": ["@clack/core@1.3.0", "", { "dependencies": { "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-xJPHpAmEQUBrXSLx0gF+q5K/IyihXpsHZcha+jB+tyahsKRK3Dxo4D0coZDewHo12NhiuzC3dTtMPbm53GEAAA=="],
 
     "@clack/prompts": ["@clack/prompts@1.3.0", "", { "dependencies": { "@clack/core": "1.3.0", "fast-string-width": "^3.0.2", "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-GgcWwRCs/xPtaqlMy8qRhPnZf9vlWcWZNHAitnVQ3yk7JmSralSiq5q07yaffYE8SogtDm7zFeKccx1QNVARpw=="],
+
+    "@ctrl/tinycolor": ["@ctrl/tinycolor@4.2.0", "", {}, "sha512-kzyuwOAQnXJNLS9PSyrk0CWk35nWJW/zl/6KvnTBMFK65gm7U1/Z5BqjxeapjZCIhQcM/DsrEmcbRwDyXyXK4A=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
 
@@ -106,6 +112,18 @@
     "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
+
+    "@expressive-code/core": ["@expressive-code/core@0.42.0", "", { "dependencies": { "@ctrl/tinycolor": "^4.0.4", "hast-util-select": "^6.0.2", "hast-util-to-html": "^9.0.1", "hast-util-to-text": "^4.0.1", "hastscript": "^9.0.0", "postcss": "^8.4.38", "postcss-nested": "^6.0.1", "unist-util-visit": "^5.0.0", "unist-util-visit-parents": "^6.0.1" } }, "sha512-MN11+9nfmaC7sYu2BZJXAXqwkBRt8t1xTSqP+Ti1NfTEskgl6xUnzDxoaiQkg0BMzpglA0pys4dpDKquP/cyIw=="],
+
+    "@expressive-code/plugin-collapsible-sections": ["@expressive-code/plugin-collapsible-sections@0.42.0", "", { "dependencies": { "@expressive-code/core": "^0.42.0" } }, "sha512-HAksURXFxFmN/tuqIHvt8N47WVFTG7kYWZswJ1LMuts6496l9c7nBBRZCaTpce1dOLRrfGjKytWixqkgGWno8Q=="],
+
+    "@expressive-code/plugin-frames": ["@expressive-code/plugin-frames@0.42.0", "", { "dependencies": { "@expressive-code/core": "^0.42.0" } }, "sha512-XtkPm+941Uta7Y+81Acv+OA/20F1NJmJhCX6UYGKpqEIGqplNh3PTOhcURp6tcruhlzJcWcvpWy6Oigz3SrjqA=="],
+
+    "@expressive-code/plugin-line-numbers": ["@expressive-code/plugin-line-numbers@0.42.0", "", { "dependencies": { "@expressive-code/core": "^0.42.0" } }, "sha512-xY0s/b8UTF8fGrHWbJ8uX95yCDU1NpepXOTtcLBJobQV08RA7G+hzxL0BtDRso7RK4bCrJHio+BgYzI/M21BBA=="],
+
+    "@expressive-code/plugin-shiki": ["@expressive-code/plugin-shiki@0.42.0", "", { "dependencies": { "@expressive-code/core": "^0.42.0", "shiki": "^4.0.2" } }, "sha512-PMKey/kLmewttAHQezL+Y5Fx3vVssfDi3+FJOYQQS2mXP3tQspFELtKKAfsXfmSXdToZYgwoO69HJndqfE+09g=="],
+
+    "@expressive-code/plugin-text-markers": ["@expressive-code/plugin-text-markers@0.42.0", "", { "dependencies": { "@expressive-code/core": "^0.42.0" } }, "sha512-l59lUx8fq1v5g6SpmbDjiU0+7IdfbiWnAyRmtTVSpfhyq+nZMN4UcmYyu2b9Mynhzt7Gr+O+cXyEPDNb2AVWVQ=="],
 
     "@fontsource/maple-mono": ["@fontsource/maple-mono@5.2.6", "", {}, "sha512-+VAD7z8nyTkaiz2/Ww639Z5Kp/YJIL4dNMQxydqSMafNb5nKxFeoRq6W3g9WJ04IcBjdBmn0dKFNk90lyz7K+w=="],
 
@@ -329,9 +347,13 @@
 
     "astro": ["astro@6.3.5", "", { "dependencies": { "@astrojs/compiler": "^4.0.0", "@astrojs/internal-helpers": "0.9.1", "@astrojs/markdown-remark": "7.1.2", "@astrojs/telemetry": "3.3.2", "@capsizecss/unpack": "^4.0.0", "@clack/prompts": "^1.1.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.3.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "ci-info": "^4.4.0", "clsx": "^2.1.1", "common-ancestor-path": "^2.0.0", "cookie": "^1.1.1", "devalue": "^5.6.3", "diff": "^8.0.3", "dset": "^3.1.4", "es-module-lexer": "^2.0.0", "esbuild": "^0.27.3", "flattie": "^1.1.1", "fontace": "~0.4.1", "get-tsconfig": "5.0.0-beta.4", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "js-yaml": "^4.1.1", "jsonc-parser": "^3.3.1", "magic-string": "^0.30.21", "magicast": "^0.5.2", "mrmime": "^2.0.1", "neotraverse": "^0.6.18", "obug": "^2.1.1", "p-limit": "^7.3.0", "p-queue": "^9.1.0", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.4", "rehype": "^13.0.2", "semver": "^7.7.4", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "svgo": "^4.0.1", "tinyclip": "^0.1.12", "tinyexec": "^1.0.4", "tinyglobby": "^0.2.15", "ultrahtml": "^1.6.0", "unifont": "~0.7.4", "unist-util-visit": "^5.1.0", "unstorage": "^1.17.5", "vfile": "^6.0.3", "vite": "^7.3.2", "vitefu": "^1.1.2", "xxhash-wasm": "^1.1.0", "yargs-parser": "^22.0.0", "zod": "^4.3.6" }, "optionalDependencies": { "sharp": "^0.34.0" }, "bin": { "astro": "./bin/astro.mjs" } }, "sha512-gU+4KedkbTuVgz7YoVAN+9Ftnq0GaYwejxK2NbqDzB0M9dWd0f3kXZBuaM9hzbchRFoRAJfJjFtdX9LK6Ir7ZA=="],
 
+    "astro-expressive-code": ["astro-expressive-code@0.42.0", "", { "dependencies": { "rehype-expressive-code": "^0.42.0" }, "peerDependencies": { "astro": "^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta" } }, "sha512-aiTePi2Cn0mJPYWZSzP1GcxCinX9mNtJyCCshVVPSg1yRwM7ADvFJOx0FnS440M9t65hp8JH//dc2qr22Bm4ag=="],
+
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
+
+    "bcp-47-match": ["bcp-47-match@2.0.3", "", {}, "sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ=="],
 
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
 
@@ -367,9 +389,13 @@
 
     "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
 
+    "css-selector-parser": ["css-selector-parser@3.3.0", "", {}, "sha512-Y2asgMGFqJKF4fq4xHDSlFYIkeVfRsm69lQC1q9kbEsH5XtnINTMrweLkjYMeaUgiXBy/uvKeO/a1JHTNnmB2g=="],
+
     "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
 
     "css-what": ["css-what@6.2.2", "", {}, "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="],
+
+    "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
 
     "csso": ["csso@5.0.5", "", { "dependencies": { "css-tree": "~2.2.0" } }, "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ=="],
 
@@ -390,6 +416,8 @@
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
     "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
+
+    "direction": ["direction@2.0.1", "", { "bin": { "direction": "cli.js" } }, "sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA=="],
 
     "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
 
@@ -431,6 +459,8 @@
 
     "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
+    "expressive-code": ["expressive-code@0.42.0", "", { "dependencies": { "@expressive-code/core": "^0.42.0", "@expressive-code/plugin-frames": "^0.42.0", "@expressive-code/plugin-shiki": "^0.42.0", "@expressive-code/plugin-text-markers": "^0.42.0" } }, "sha512-V5DtJLEKuj4wf9O6IRtPtRObkMVy2ggR+S0MdjrTw6m58krZnDioyhW1si3Y04c5YPeooP4nd85Yq9NwEVHS4g=="],
+
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
     "fast-string-truncated-width": ["fast-string-truncated-width@3.0.3", "", {}, "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="],
@@ -465,11 +495,15 @@
 
     "hast-util-from-parse5": ["hast-util-from-parse5@8.0.3", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "devlop": "^1.0.0", "hastscript": "^9.0.0", "property-information": "^7.0.0", "vfile": "^6.0.0", "vfile-location": "^5.0.0", "web-namespaces": "^2.0.0" } }, "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg=="],
 
+    "hast-util-has-property": ["hast-util-has-property@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-MNilsvEKLFpV604hwfhVStK0usFY/QmM5zX16bo7EjnAEGofr5YyI37kzopBlZJkHD4t887i+q/C8/tr5Q94cA=="],
+
     "hast-util-is-element": ["hast-util-is-element@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g=="],
 
     "hast-util-parse-selector": ["hast-util-parse-selector@4.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A=="],
 
     "hast-util-raw": ["hast-util-raw@9.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "@ungap/structured-clone": "^1.0.0", "hast-util-from-parse5": "^8.0.0", "hast-util-to-parse5": "^8.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "parse5": "^7.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0", "web-namespaces": "^2.0.0", "zwitch": "^2.0.0" } }, "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw=="],
+
+    "hast-util-select": ["hast-util-select@6.0.4", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "bcp-47-match": "^2.0.0", "comma-separated-tokens": "^2.0.0", "css-selector-parser": "^3.0.0", "devlop": "^1.0.0", "direction": "^2.0.0", "hast-util-has-property": "^3.0.0", "hast-util-to-string": "^3.0.0", "hast-util-whitespace": "^3.0.0", "nth-check": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "unist-util-visit": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-RqGS1ZgI0MwxLaKLDxjprynNzINEkRHY2i8ln4DDjgv9ZhcYVIHN9rlpiYsqtFwrgpYU361SyWDQcGNIBVu3lw=="],
 
     "hast-util-to-estree": ["hast-util-to-estree@3.1.3", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-attach-comments": "^3.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "style-to-js": "^1.0.0", "unist-util-position": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w=="],
 
@@ -478,6 +512,8 @@
     "hast-util-to-jsx-runtime": ["hast-util-to-jsx-runtime@2.3.6", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "style-to-js": "^1.0.0", "unist-util-position": "^5.0.0", "vfile-message": "^4.0.0" } }, "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg=="],
 
     "hast-util-to-parse5": ["hast-util-to-parse5@8.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "web-namespaces": "^2.0.0", "zwitch": "^2.0.0" } }, "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA=="],
+
+    "hast-util-to-string": ["hast-util-to-string@3.0.1", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A=="],
 
     "hast-util-to-text": ["hast-util-to-text@4.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "hast-util-is-element": "^3.0.0", "unist-util-find-after": "^5.0.0" } }, "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A=="],
 
@@ -715,6 +751,10 @@
 
     "postcss": ["postcss@8.5.14", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg=="],
 
+    "postcss-nested": ["postcss-nested@6.2.0", "", { "dependencies": { "postcss-selector-parser": "^6.1.1" }, "peerDependencies": { "postcss": "^8.2.14" } }, "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ=="],
+
+    "postcss-selector-parser": ["postcss-selector-parser@6.1.2", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg=="],
+
     "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
 
     "prettier-plugin-astro": ["prettier-plugin-astro@0.14.1", "", { "dependencies": { "@astrojs/compiler": "^2.9.1", "prettier": "^3.0.0", "sass-formatter": "^0.7.6" } }, "sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw=="],
@@ -742,6 +782,8 @@
     "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
 
     "rehype": ["rehype@13.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "rehype-parse": "^9.0.0", "rehype-stringify": "^10.0.0", "unified": "^11.0.0" } }, "sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A=="],
+
+    "rehype-expressive-code": ["rehype-expressive-code@0.42.0", "", { "dependencies": { "expressive-code": "^0.42.0" } }, "sha512-8rp/1YMEVVSYbtz+bFBx+uSx3vA4i4T8RwRm5Q/IWbucQnnQqQ0hDqtmKOr8tv+59Cik6cu5aH3WPo0I7csuTA=="],
 
     "rehype-parse": ["rehype-parse@9.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-from-html": "^2.0.0", "unified": "^11.0.0" } }, "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag=="],
 
@@ -864,6 +906,8 @@
     "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
 
     "unstorage": ["unstorage@1.17.5", "", { "dependencies": { "anymatch": "^3.1.3", "chokidar": "^5.0.0", "destr": "^2.0.5", "h3": "^1.15.10", "lru-cache": "^11.2.7", "node-fetch-native": "^1.6.7", "ofetch": "^1.5.1", "ufo": "^1.6.3" }, "peerDependencies": { "@azure/app-configuration": "^1.8.0", "@azure/cosmos": "^4.2.0", "@azure/data-tables": "^13.3.0", "@azure/identity": "^4.6.0", "@azure/keyvault-secrets": "^4.9.0", "@azure/storage-blob": "^12.26.0", "@capacitor/preferences": "^6 || ^7 || ^8", "@deno/kv": ">=0.9.0", "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0", "@planetscale/database": "^1.19.0", "@upstash/redis": "^1.34.3", "@vercel/blob": ">=0.27.1", "@vercel/functions": "^2.2.12 || ^3.0.0", "@vercel/kv": "^1 || ^2 || ^3", "aws4fetch": "^1.0.20", "db0": ">=0.2.1", "idb-keyval": "^6.2.1", "ioredis": "^5.4.2", "uploadthing": "^7.4.4" }, "optionalPeers": ["@azure/app-configuration", "@azure/cosmos", "@azure/data-tables", "@azure/identity", "@azure/keyvault-secrets", "@azure/storage-blob", "@capacitor/preferences", "@deno/kv", "@netlify/blobs", "@planetscale/database", "@upstash/redis", "@vercel/blob", "@vercel/functions", "@vercel/kv", "aws4fetch", "db0", "idb-keyval", "ioredis", "uploadthing"] }, "sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg=="],
+
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 

--- a/ec.config.mjs
+++ b/ec.config.mjs
@@ -1,0 +1,85 @@
+import fs from 'node:fs';
+import { pluginCollapsibleSections } from '@expressive-code/plugin-collapsible-sections';
+import { pluginLineNumbers } from '@expressive-code/plugin-line-numbers';
+import { defineEcConfig, setAlpha } from 'astro-expressive-code';
+import { parse } from 'smol-toml';
+
+const siteToml = parse(fs.readFileSync(new URL('./src/config/site.toml', import.meta.url), 'utf8'));
+
+const code = {
+  lightTheme: 'github-light',
+  darkTheme: 'github-dark',
+  lineNumbers: true,
+  wrap: true,
+  preserveIndent: true,
+  collapseStyle: 'collapsible-auto',
+  ...(siteToml.config?.code ?? {}),
+};
+
+const isDarkCodeTheme = ({ theme }) => theme.name === code.darkTheme;
+
+export default defineEcConfig({
+  plugins: [pluginLineNumbers(), pluginCollapsibleSections()],
+  defaultLocale: 'zh-CN',
+  themes: [code.lightTheme, code.darkTheme],
+  themeCssRoot: ':root',
+  themeCssSelector: (theme) =>
+    theme.name === code.darkTheme ? '[data-theme="dark"]' : '[data-theme="light"]',
+  useDarkModeMediaQuery: false,
+  removeUnusedThemes: true,
+  defaultProps: {
+    wrap: code.wrap,
+    preserveIndent: code.preserveIndent,
+    showLineNumbers: code.lineNumbers,
+    collapseStyle: code.collapseStyle,
+  },
+  frames: {
+    extractFileNameFromCode: true,
+  },
+  styleOverrides: {
+    borderRadius: '1px',
+    borderWidth: '1px',
+    borderColor: 'var(--paper-line-strong)',
+    uiFontFamily: 'var(--font-meta)',
+    uiFontSize: '0.88rem',
+    codeFontFamily: 'var(--font-code)',
+    codeFontSize: '0.9rem',
+    codeLineHeight: '1.65',
+    codePaddingBlock: '1rem',
+    codePaddingInline: '1.15rem',
+    codeBackground: 'var(--paper-surface-muted)',
+    frames: {
+      editorActiveTabBackground: 'var(--paper-surface-muted)',
+      editorActiveTabIndicatorTopColor: 'var(--paper-accent)',
+      editorTabBarBackground: 'var(--paper-control)',
+      editorBackground: 'var(--paper-surface-muted)',
+      frameBoxShadowCssValue: 'var(--paper-shadow)',
+      inlineButtonBackgroundActiveOpacity: '0.16',
+      inlineButtonBackgroundHoverOrFocusOpacity: '0.1',
+      terminalTitlebarBackground: 'var(--paper-control)',
+      terminalBackground: 'var(--paper-surface-muted)',
+      tooltipSuccessBackground: ({ theme }) =>
+        setAlpha(theme.colors['terminal.ansiGreen'] || '#3f8f58', 0.94),
+    },
+    textMarkers: {
+      lineMarkerAccentWidth: '0.2rem',
+      backgroundOpacity: '0.24',
+      borderOpacity: '0.62',
+      markBackground: (context) =>
+        isDarkCodeTheme(context) ? 'rgba(120, 151, 255, 0.26)' : 'rgba(82, 111, 190, 0.14)',
+      markBorderColor: (context) =>
+        isDarkCodeTheme(context) ? 'rgba(168, 188, 255, 0.74)' : 'rgba(82, 111, 190, 0.38)',
+      insBackground: (context) =>
+        isDarkCodeTheme(context) ? 'rgba(82, 164, 112, 0.24)' : 'rgba(62, 138, 86, 0.13)',
+      insBorderColor: (context) =>
+        isDarkCodeTheme(context) ? 'rgba(133, 205, 156, 0.68)' : 'rgba(62, 138, 86, 0.36)',
+      delBackground: (context) =>
+        isDarkCodeTheme(context) ? 'rgba(207, 96, 86, 0.22)' : 'rgba(184, 74, 65, 0.12)',
+      delBorderColor: (context) =>
+        isDarkCodeTheme(context) ? 'rgba(238, 147, 137, 0.64)' : 'rgba(184, 74, 65, 0.34)',
+    },
+    collapsibleSections: {
+      closedBackgroundColor: 'var(--paper-control)',
+    },
+  },
+});

--- a/package.json
+++ b/package.json
@@ -20,11 +20,15 @@
     "@astrojs/mdx": "^5.0.6",
     "@astrojs/rss": "^4.0.18",
     "@astrojs/sitemap": "^3.7.2",
+    "@expressive-code/plugin-collapsible-sections": "^0.42.0",
+    "@expressive-code/plugin-line-numbers": "^0.42.0",
     "@fontsource/maple-mono": "^5.2.6",
     "@tailwindcss/vite": "^4.3.0",
     "astro": "^6.3.5",
+    "astro-expressive-code": "^0.42.0",
     "lucide-astro": "^0.556.0",
     "sharp": "^0.34.5",
+    "smol-toml": "^1.6.1",
     "tailwindcss": "^4.3.0"
   },
   "devDependencies": {

--- a/src/config/site.toml
+++ b/src/config/site.toml
@@ -14,6 +14,14 @@ showTrail = true
 # green-soft, green-vivid, rose-soft, pink-soft, purple-soft, blue-soft, orange-soft, brown-soft
 palette = "green-soft"
 
+[config.code]
+lightTheme = "catppuccin-latte"
+darkTheme = "catppuccin-macchiato"
+lineNumbers = true
+wrap = true
+preserveIndent = true
+collapseStyle = "collapsible-auto"
+
 [config.comments]
 enabled = true
 provider = "giscus"
@@ -91,7 +99,11 @@ href = "/about"
 layout = "grid"
 
 [config.home.quote]
-text = ["Navigate your world,", "Showcase your story,", "and keep everything in one place."]
+text = [
+  "Navigate your world,",
+  "Showcase your story,",
+  "and keep everything in one place.",
+]
 image = "/images/logo-with-name.png"
 
 [config.home.intro]

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -49,6 +49,22 @@ const paletteSchema = z.enum([
   'brown-soft',
 ]);
 
+const collapseStyleSchema = z.enum([
+  'github',
+  'collapsible-start',
+  'collapsible-end',
+  'collapsible-auto',
+]);
+
+const defaultCodeConfig = {
+  lightTheme: 'catppuccin-latte',
+  darkTheme: 'catppuccin-macchiato',
+  lineNumbers: true,
+  wrap: true,
+  preserveIndent: true,
+  collapseStyle: 'github',
+} as const;
+
 const defaultGiscusConfig = {
   repo: '',
   repo_id: '',
@@ -134,6 +150,17 @@ const siteConfig = defineCollection({
       .default({
         palette: 'green-soft',
       }),
+    code: z
+      .object({
+        lightTheme: z.string().optional().default(defaultCodeConfig.lightTheme),
+        darkTheme: z.string().optional().default(defaultCodeConfig.darkTheme),
+        lineNumbers: z.boolean().optional().default(defaultCodeConfig.lineNumbers),
+        wrap: z.boolean().optional().default(defaultCodeConfig.wrap),
+        preserveIndent: z.boolean().optional().default(defaultCodeConfig.preserveIndent),
+        collapseStyle: collapseStyleSchema.optional().default(defaultCodeConfig.collapseStyle),
+      })
+      .optional()
+      .default(defaultCodeConfig),
     comments: z
       .object({
         enabled: z.boolean().optional().default(true),

--- a/src/content/blog/expressive-code.md
+++ b/src/content/blog/expressive-code.md
@@ -1,0 +1,187 @@
+---
+title: '使用 Expressive Code 展示代码块'
+description: ''
+date: '2026-05-24T16:21:33.842Z'
+draft: false
+showHeroImage: false
+tags: []
+comments: true
+sidebar:
+  enable: true
+  toc: true
+  relatedPosts: true
+---
+
+我们采用表达力更强，更美观的 [Expressive Code](https://expressive-code.com/) 来展示代码块，更多的语法上的用法可以关注官方的文档。
+
+# 配置
+
+我们在 `config/site.toml` 中可以对代码块使用的主题以及一些插件进行配置：
+
+```toml
+[config.code]
+lightTheme = "catppuccin-latte"
+darkTheme = "catppuccin-macchiato"
+lineNumbers = true
+wrap = true
+preserveIndent = true
+collapseStyle = "collapsible-auto"
+```
+
+我们的主题默认启用以下功能：
+
+1. 显示行号
+2. 自动折行
+3. 折叠长代码
+
+# 主题
+
+我们可以在 [主题](https://expressive-code.com/guides/themes/) 页面来找到支持的主题，自行填写中意的代码主题即可
+
+但是注意，如果只想要单一主题的话（例如都是暗色主题），那么需要填写为：
+
+```toml {2}
+[config.code]
+lightTheme = "catppuccin-macchiato"
+darkTheme = "catppuccin-macchiato"
+```
+
+# 显示行号与标题
+
+我们可以通过 `showLineNumbers` 这个选项来知道显式的决定是否显示行号（默认为显示），例如：
+
+````md "showLineNumbers=false"
+```js showLineNumbers=false
+const foo = 'bar';
+```
+````
+
+其显示为：
+
+```js showLineNumbers=false
+const foo = 'bar';
+```
+
+如果想要显示标题，我们可以考虑：
+
+````md
+```js title="这是标题"
+const foo = 'bar';
+```
+````
+
+显示为：
+
+```js title="这是标题"
+const foo = 'bar';
+```
+
+# 高亮行与文字
+
+高亮行支持以下三种格式：
+
+1. github 的插入格式，写法为 `ins={"desc": lineno-lineno}`
+2. github 的删除格式，写法为 `del={"desc": lineno-lineno}`
+3. 普通高亮模式，写法为 `{"desc": lineno-lineno}`
+
+注意，`"desc"` 也会占用一行，如果要添加这样的描述，需要注意自己的行数没有数错。
+
+例如：
+
+````md
+```js ins={1-3} del={5} {"desc": 6-7}
+const line1 = 'insert';
+const line2 = 'ii';
+const line3 = 'nn';
+
+const line5 = 'del';
+
+const line7 = 'mark';
+```
+````
+
+显示为：
+
+```js ins={1-3} del={5} {"desc": 6-7}
+const line1 = 'insert';
+const line2 = 'ii';
+const line3 = 'nn';
+
+const line5 = 'del';
+
+const line7 = 'mark';
+```
+
+而高亮文字，可以写为：
+
+````md
+```js "foo"
+const foo = 'foo' + 'bar';
+```
+````
+
+显示为：
+
+```js "foo"
+const foo = 'foo' + 'bar';
+```
+
+# 长代码折叠
+
+````md "collapse={1-5, 12-14, 21-24}"
+```js collapse={1-5, 12-14, 21-24}
+// All this boilerplate setup code will be collapsed
+import { someBoilerplateEngine } from '@example/some-boilerplate';
+import { evenMoreBoilerplate } from '@example/even-more-boilerplate';
+
+const engine = someBoilerplateEngine(evenMoreBoilerplate());
+
+// This part of the code will be visible by default
+engine.doSomething(1, 2, 3, calcFn);
+
+function calcFn() {
+  // You can have multiple collapsed sections
+  const a = 1;
+  const b = 2;
+  const c = a + b;
+
+  // This will remain visible
+  console.log(`Calculation result: ${a} + ${b} = ${c}`);
+  return c;
+}
+
+// All this code until the end of the block will be collapsed again
+engine.closeConnection();
+engine.freeMemory();
+engine.shutdown({ reason: 'End of example boilerplate code' });
+```
+````
+
+我们默认的格式为 `github` 折叠格式，显示为：
+
+```js collapse={1-5, 12-14, 21-24}
+// All this boilerplate setup code will be collapsed
+import { someBoilerplateEngine } from '@example/some-boilerplate';
+import { evenMoreBoilerplate } from '@example/even-more-boilerplate';
+
+const engine = someBoilerplateEngine(evenMoreBoilerplate());
+
+// This part of the code will be visible by default
+engine.doSomething(1, 2, 3, calcFn);
+
+function calcFn() {
+  // You can have multiple collapsed sections
+  const a = 1;
+  const b = 2;
+  const c = a + b;
+
+  // This will remain visible
+  console.log(`Calculation result: ${a} + ${b} = ${c}`);
+  return c;
+}
+
+// All this code until the end of the block will be collapsed again
+engine.closeConnection();
+engine.freeMemory();
+engine.shutdown({ reason: 'End of example boilerplate code' });
+```

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -16,6 +16,12 @@ export async function getThemePalette() {
   return theme.palette;
 }
 
+export async function getCodeConfig() {
+  const { code } = await getSiteConfig();
+
+  return code;
+}
+
 export type SiteConfig = Awaited<ReturnType<typeof getSiteConfig>>;
 export type ThemePalette = SiteConfig['theme']['palette'];
 export type SiteProfile = SiteConfig['profile'];
@@ -23,6 +29,7 @@ export type SiteLink = SiteConfig['topNav']['links'][number];
 export type SiteVibe = SiteConfig['vibe'];
 export type SiteSearch = SiteConfig['search'];
 export type SiteBlog = SiteConfig['blog'];
+export type SiteCode = SiteConfig['code'];
 export type HomeNavigationItem = SiteConfig['home']['navigation'][number];
 export type HomeConnectItem = SiteConfig['home']['connect'][number];
 export type HomeDoingItem = SiteConfig['home']['doing'][number];

--- a/src/layouts/BlogArticle.astro
+++ b/src/layouts/BlogArticle.astro
@@ -323,7 +323,7 @@ const hasSidebar = shouldRenderSidebar && hasToc;
     font-size: 1.08rem;
   }
 
-  .article-content :global(pre),
+  .article-content :global(pre:not([data-language])),
   .code-block {
     overflow-x: auto;
     border: 1px solid var(--paper-line-strong);
@@ -332,19 +332,29 @@ const hasSidebar = shouldRenderSidebar && hasToc;
     color: var(--paper-ink);
   }
 
-  .article-content :global(pre) {
+  .article-content :global(pre:not([data-language])) {
     padding: 20px;
   }
 
-  .article-content :global(code) {
+  .article-content :global(:not(pre) > code) {
     font-family: var(--font-code);
     border-radius: 7px;
     background: var(--paper-control);
     color: var(--paper-ink);
   }
 
-  .article-content :global(pre code) {
+  .article-content :global(pre:not([data-language]) > code) {
     background: transparent;
+  }
+
+  .article-content :global(.expressive-code) {
+    margin: 28px 0 30px;
+    font-family: var(--font-code);
+  }
+
+  .article-content :global(.expressive-code .frame) {
+    overflow: hidden;
+    border-radius: 7px;
   }
 
   .code-block {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,6 +4,7 @@
 @import '@fontsource/maple-mono/700.css';
 
 @import './palettes.css';
+
 @font-face {
   font-family: 'LXGW UI Subset';
   src: url('/fonts/lxgw-ui-subset.woff2') format('woff2');
@@ -109,6 +110,7 @@
   --paper-theme-color: #171b18;
   color-scheme: dark;
 }
+
 body {
   font-family: var(--font-body);
   margin: 0;
@@ -122,12 +124,14 @@ body {
   font-size: 20px;
   line-height: 1.7;
 }
+
 main {
   width: min(100%, var(--layout-shell-width));
   max-width: none;
   margin: auto;
   padding: var(--layout-page-top) var(--layout-page-gutter) var(--layout-page-bottom);
 }
+
 h1,
 h2,
 h3,
@@ -138,80 +142,84 @@ h6 {
   color: rgb(var(--black));
   line-height: 1.2;
 }
+
 h1 {
   font-size: 3.052em;
 }
+
 h2 {
   font-size: 2.441em;
 }
+
 h3 {
   font-size: 1.953em;
 }
+
 h4 {
   font-size: 1.563em;
 }
+
 h5 {
   font-size: 1.25em;
 }
+
 strong,
 b {
   font-weight: 700;
 }
+
 a {
   color: var(--accent);
 }
+
 a:hover {
   color: var(--accent);
 }
+
 p {
   margin-bottom: 1em;
 }
+
 .prose p {
   margin-bottom: 2em;
 }
+
 textarea {
   width: 100%;
   font-size: 16px;
 }
+
 input {
   font-size: 16px;
 }
+
 table {
   width: 100%;
 }
+
 img {
   max-width: 100%;
   height: auto;
   border-radius: 8px;
 }
-code {
-  font-family: var(--font-code);
-  padding: 2px 5px;
-  background-color: rgb(var(--gray-light));
-  border-radius: 2px;
-}
-pre {
-  font-family: var(--font-code);
-  padding: 1.5em;
-  border-radius: 8px;
-}
-pre > code {
-  all: unset;
-}
+
 blockquote {
   border-left: 4px solid var(--accent);
   padding: 0 0 0 20px;
   margin: 0;
   font-size: 1.333em;
 }
+
 hr {
   border: none;
   border-top: 1px solid rgb(var(--gray-light));
 }
+
 @media (max-width: 720px) {
   body {
     font-size: 18px;
   }
+
   main {
     padding: 92px 18px 42px;
   }


### PR DESCRIPTION
This pr solved #20, adding the `expressive-code` to display code blocks, rather than using native css.