### PR TITLE
fix:load Waline CSS when Waline is enabled

### DIFF
--- a/src/layouts/BlogArticle.astro
+++ b/src/layouts/BlogArticle.astro
@@ -6,8 +6,9 @@ import RelatedPosts from '../components/blog/RelatedPosts.astro';
 import TableOfContents from '../components/blog/TableOfContents.astro';
 import BaseHead from '../components/BaseHead.astro';
 import CommentSection from '../components/comments/CommentSection.astro';
-import { getThemePalette } from '../data/site';
+import { getThemePalette, getSiteConfig } from '../data/site';
 import { sortByDateDesc } from '../utils/content-dates';
+const { comments } = await getSiteConfig();
 
 type SidebarConfig = {
   enable?: boolean;
@@ -101,6 +102,9 @@ const hasSidebar = shouldRenderSidebar && hasToc;
 <html lang="zh-CN" data-palette={palette}>
   <head>
     <BaseHead title={title} description={description} />
+    {comments.provider === 'waline' && comments.enabled && (
+      <link rel="stylesheet" href="https://unpkg.com/@waline/client@v3/dist/waline.css" />
+    )}
   </head>
   <body class="blog-detail-page">
     <BlogTopNav showTocIcon={hasToc} tocItems={tocItems} />


### PR DESCRIPTION
### 描述

本 PR 在博客文章页面增加了对留言系统的条件判断。当检测到启用的留言系统是 `waline` 时，会加载 Waline 对应的 CSS 样式表。

### 为什么做出此改动？

在此之前，未发现加载waline对应css的逻辑。实测在本地运行之后，缺少对应的css引入。

### 改动类型
- [x] 新功能（非破坏性改动，增加了新逻辑）
- [ ] 修复 Bug
- [ ] 性能优化