### PR TITLE
feat(home): homepage doing section now dynamically displays latest blog posts

### DIFF
--- a/src/components/widgets/DoingCard.astro
+++ b/src/components/widgets/DoingCard.astro
@@ -75,6 +75,12 @@ const { items } = Astro.props as { items: DoingItem[] };
     border-top: 1px solid var(--paper-line);
     color: var(--paper-ink);
     font-size: 0.98rem;
+    transition: color 0.2s ease;
+    cursor: default;
+  }
+
+  li:has(.doing-link:hover) {
+    color: var(--paper-accent);
   }
 
   li::before {
@@ -95,10 +101,5 @@ const { items } = Astro.props as { items: DoingItem[] };
   .doing-link {
     color: inherit;
     text-decoration: none;
-    transition: color 0.2s ease;
-  }
-
-  .doing-link:hover {
-    color: var(--paper-accent);
   }
 </style>

--- a/src/components/widgets/DoingCard.astro
+++ b/src/components/widgets/DoingCard.astro
@@ -99,7 +99,7 @@ const { items } = Astro.props as { items: DoingItem[] };
   }
 
   .doing-link {
-    color: inherit;
-    text-decoration: none;
+    color: inherit !important;
+    text-decoration: none !important;
   }
 </style>

--- a/src/components/widgets/DoingCard.astro
+++ b/src/components/widgets/DoingCard.astro
@@ -4,6 +4,7 @@ import Icon from '../Icon.astro';
 interface DoingItem {
   text: string;
   mark: string;
+  href?: string;
 }
 
 const { items } = Astro.props as { items: DoingItem[] };
@@ -15,7 +16,11 @@ const { items } = Astro.props as { items: DoingItem[] };
     {
       items.map((item) => (
         <li>
-          <span>{item.text}</span>
+          {item.href ? (
+            <a href={item.href} class="doing-link">{item.text}</a>
+          ) : (
+            <span>{item.text}</span>
+          )}
           <strong aria-hidden="true">{item.mark}</strong>
         </li>
       ))
@@ -85,5 +90,15 @@ const { items } = Astro.props as { items: DoingItem[] };
   strong {
     font-size: 0.82rem;
     text-align: right;
+  }
+
+  .doing-link {
+    color: inherit;
+    text-decoration: none;
+    transition: color 0.2s ease;
+  }
+
+  .doing-link:hover {
+    color: var(--paper-accent);
   }
 </style>

--- a/src/config/site.toml
+++ b/src/config/site.toml
@@ -98,6 +98,7 @@ href = "/about"
 
 [config.home]
 layout = "grid"
+doingDynamic = true
 
 [config.home.quote]
 text = [

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -278,6 +278,7 @@ const siteConfig = defineCollection({
         }),
       navigation: z.array(navigationItemSchema),
       connect: z.array(linkSchema.required({ icon: true })),
+      doingDynamic: z.boolean().optional().default(false),
       doing: z.array(
         z.object({
           text: z.string(),

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -18,11 +18,15 @@ if (home.doingDynamic) {
     .sort((a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime());
   const doingCount = 5;
   const latestPosts = allPosts.slice(0, doingCount);
-  doingItems = latestPosts.map((post, i) => ({
-    text: post.data.title,
-    mark: String(i + 1).padStart(2, '0'),
-    href: `/blog/${post.id}`,
-  }));
+  if (latestPosts.length > 0) {
+    doingItems = latestPosts.map((post, i) => ({
+      text: post.data.title,
+      mark: String(i + 1).padStart(2, '0'),
+      href: `/blog/${post.id}`,
+    }));
+  } else {
+    doingItems = home.doing;
+  }
 } else {
   doingItems = home.doing;
 }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,8 +7,20 @@ import BlogHeatmap from '../components/widgets/BlogHeatmap.astro';
 import DoingCard from '../components/widgets/DoingCard.astro';
 import { getSiteConfig } from '../data/site';
 import BaseLayout from '../layouts/BaseLayout.astro';
+import { getCollection } from 'astro:content';
 
 const { home, profile, site } = await getSiteConfig();
+
+// Build doing items from the 5 most recent blog posts
+const allPosts = (await getCollection('blog', ({ data }) => !data.draft))
+  .sort((a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime());
+const doingCount = 5;
+const latestPosts = allPosts.slice(0, doingCount);
+const doingItems = latestPosts.map((post, i) => ({
+  text: post.data.title,
+  mark: String(i + 1).padStart(2, '0'),
+  href: `/blog/${post.id}`,
+}));
 ---
 
 <BaseLayout title={site.pageTitle} description={site.pageDescription}>
@@ -38,7 +50,7 @@ const { home, profile, site } = await getSiteConfig();
     </Fragment>
 
     <Fragment slot="recently">
-      <DoingCard items={home.doing} />
+      <DoingCard items={doingItems} />
     </Fragment>
   </DashboardFlow>
 </BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,16 +11,21 @@ import { getCollection } from 'astro:content';
 
 const { home, profile, site } = await getSiteConfig();
 
-// Build doing items from the 5 most recent blog posts
-const allPosts = (await getCollection('blog', ({ data }) => !data.draft))
-  .sort((a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime());
-const doingCount = 5;
-const latestPosts = allPosts.slice(0, doingCount);
-const doingItems = latestPosts.map((post, i) => ({
-  text: post.data.title,
-  mark: String(i + 1).padStart(2, '0'),
-  href: `/blog/${post.id}`,
-}));
+// Build doing items: dynamic from latest blog posts or static from config
+let doingItems: { text: string; mark: string; href?: string }[];
+if (home.doingDynamic) {
+  const allPosts = (await getCollection('blog', ({ data }) => !data.draft))
+    .sort((a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime());
+  const doingCount = 5;
+  const latestPosts = allPosts.slice(0, doingCount);
+  doingItems = latestPosts.map((post, i) => ({
+    text: post.data.title,
+    mark: String(i + 1).padStart(2, '0'),
+    href: `/blog/${post.id}`,
+  }));
+} else {
+  doingItems = home.doing;
+}
 ---
 
 <BaseLayout title={site.pageTitle} description={site.pageDescription}>


### PR DESCRIPTION

## Overview

Upgrade the homepage "Recently" section from static configuration to dynamically displaying the latest blog posts, while keeping static entries as a fallback.

## Changes

### New Features
- The "Recently" section now dynamically reads and displays the latest 5 blog post titles
- Each post is clickable and navigates to the corresponding blog detail page (`/blog/{id}`)
- Added `doingDynamic` config option (`site.toml → [config.home]`); set to `true` to enable dynamic mode, omit or set to `false` to use static entries

### Style Improvements
- On hover, the post title and the adjacent mark number (01/02/…) change color together for a consistent interaction
- Link text style matches static entries exactly — no underline, color inherits from parent

### Robustness
- When `doingDynamic = true` but no blog posts are published, automatically falls back to the static `doing` entries in `site.toml`, preventing an empty section

## Configuration

```toml
# site.toml
[config.home]
doingDynamic = true   # dynamic latest posts; omit or false to use static entries
```

## Files Changed

| File | Description |
|------|-------------|
| `src/pages/index.astro` | Homepage logic: query posts, build doing items, fallback handling |
| `src/components/widgets/DoingCard.astro` | Component: add optional `href` field, render links, hover color sync |
| `src/content.config.ts` | Schema: add `doingDynamic` boolean field (default `false`) |
| `src/config/site.toml` | Config: enable `doingDynamic = true` |

## Screenshots or recordings
<img width="1344" height="879" alt="blog" src="https://github.com/user-attachments/assets/ae1cbe72-7085-492c-a4a7-6048aace51f4" />

## Test Plan

- [x] `doingDynamic = true` with posts: displays latest post titles, clickable to navigate
- [x] `doingDynamic = true` without posts: falls back to static entries
- [x] `doingDynamic = false` or unset: behavior unchanged from before
- [x] Hover: title and mark number color change in sync
- [x] Link text: no underline, style matches static entries
