### PR TITLE
Fix:修正navbar切頁時的位置跳動

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -250,6 +250,7 @@ hr {
 
 html {
   background: var(--paper-bg);
+  scrollbar-gutter: stable;
 }
 
 body {


### PR DESCRIPTION
## 調整內容 
修正不同頁面切換時 navbar 會左右位移的問題。

## 原因
部分頁面有scrollbar，部分頁面沒有。 
Windows 上 scrollbar 會佔用畫面寬度，導致 fixed navbar 的置中基準在切頁時不同。

## 解法

在global.css 中 `html` 加上：
```css
scrollbar-gutter: stable;
```
讓瀏覽器固定預留 scrollbar 空間，避免 navbar 在頁面切換時跳動。

## 修正前:

https://github.com/user-attachments/assets/edc0e946-1450-4c09-8ebd-2b67e67bd190

## 修正後:

https://github.com/user-attachments/assets/d06a8234-14a9-4d7d-89fa-438eead269f0

