### PR TITLE
feat: improve vibe image flow layout

### DIFF
--- a/src/pages/vibe.astro
+++ b/src/pages/vibe.astro
@@ -6,6 +6,7 @@ import FormattedDate from '../components/FormattedDate.astro';
 import SmartImage from '../components/SmartImage.astro';
 import BlogTopNav from '../components/blog/BlogTopNav.astro';
 import { getSiteConfig } from '../data/site';
+import { getVibeImageLayout } from '../utils/vibe-image-layout';
 
 const { site, vibe: vibeConfig, theme } = await getSiteConfig();
 const palette = theme.palette;
@@ -19,8 +20,9 @@ const vibes = await Promise.all(
   vibeEntries.map(async (entry, index) => {
     const { Content } = await render(entry);
     const align = entry.data.align ?? (index % 2 === 0 ? 'left' : 'right');
+    const imageLayout = getVibeImageLayout(entry.data.images.length);
 
-    return { entry, Content, align };
+    return { entry, Content, align, imageLayout };
   }),
 );
 ---
@@ -219,13 +221,11 @@ const vibes = await Promise.all(
         opacity: 0.78;
       }
 
-      .vibe-item.right .vibe-meta,
-      .vibe-item.right .vibe-images {
+      .vibe-item.right .vibe-meta {
         justify-content: flex-end;
       }
 
-      .vibe-item.center .vibe-meta,
-      .vibe-item.center .vibe-images {
+      .vibe-item.center .vibe-meta {
         justify-content: center;
       }
 
@@ -282,21 +282,55 @@ const vibes = await Promise.all(
       }
 
       .vibe-images {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 10px;
-        align-items: flex-start;
+        --vibe-image-active-columns: var(--vibe-image-columns);
+        --vibe-image-gap: 10px;
+        --vibe-image-cell: clamp(132px, 21vw, 172px);
+
+        display: grid;
+        grid-template-columns: repeat(var(--vibe-image-active-columns), minmax(0, 1fr));
+        gap: var(--vibe-image-gap);
         margin: 16px 0 18px;
+        width: min(
+          100%,
+          calc(
+            (var(--vibe-image-columns) * var(--vibe-image-cell)) +
+              ((var(--vibe-image-columns) - 1) * var(--vibe-image-gap))
+          )
+        );
+      }
+
+      .vibe-item.right .vibe-images {
+        margin-left: auto;
+      }
+
+      .vibe-item.center .vibe-images {
+        margin-right: auto;
+        margin-left: auto;
+      }
+
+      .vibe-images[data-vibe-image-count='1'] {
+        width: min(100%, 420px);
       }
 
       .vibe-image {
-        flex: 1 1 210px;
-        max-width: min(100%, 420px);
         margin: 0;
         overflow: hidden;
+        aspect-ratio: 1;
         border-radius: 10px;
         opacity: 0.94;
         rotate: -0.6deg;
+      }
+
+      .vibe-images[data-vibe-image-count='1'] .vibe-image {
+        aspect-ratio: auto;
+      }
+
+      .vibe-image.is-extra {
+        display: none;
+      }
+
+      .vibe-images.is-expanded .vibe-image.is-extra {
+        display: block;
       }
 
       .vibe-image:nth-child(even) {
@@ -306,9 +340,48 @@ const vibes = await Promise.all(
       .vibe-image img {
         display: block;
         width: 100%;
-        height: auto;
+        height: 100%;
         border-radius: 10px;
         filter: saturate(0.86) contrast(0.98);
+        object-fit: cover;
+      }
+
+      .vibe-images[data-vibe-image-count='1'] .vibe-image img {
+        height: auto;
+        object-fit: initial;
+      }
+
+      .vibe-image-toggle {
+        grid-column: 1 / -1;
+        justify-self: center;
+        margin: 4px 0 0;
+        padding: 0;
+        border: 0;
+        border-radius: 0;
+        background: transparent;
+        color: var(--paper-ink-faint);
+        cursor: pointer;
+        font-family: var(--font-meta);
+        font-size: 0.68rem;
+        line-height: 1.8;
+        text-decoration: underline;
+        text-decoration-color: color-mix(in srgb, currentColor 28%, transparent);
+        text-underline-offset: 0.28em;
+        opacity: 0.78;
+        transition:
+          color 160ms ease,
+          opacity 160ms ease;
+      }
+
+      .vibe-image-toggle:hover,
+      .vibe-image-toggle:focus-visible {
+        color: var(--paper-ink-soft);
+        opacity: 1;
+      }
+
+      .vibe-image-toggle:focus-visible {
+        outline: 1px solid color-mix(in srgb, var(--paper-accent) 42%, transparent);
+        outline-offset: 4px;
       }
 
       .vibe-item.quote .vibe-body {
@@ -395,9 +468,18 @@ const vibes = await Promise.all(
           line-height: 1.86;
         }
 
-        .vibe-image {
-          flex-basis: 100%;
-          max-width: 100%;
+        .vibe-images[data-vibe-image-columns='3'],
+        .vibe-images[data-vibe-image-columns='4'] {
+          --vibe-image-active-columns: 2;
+        }
+
+        .vibe-images {
+          width: 100%;
+        }
+
+        .vibe-image-toggle {
+          min-height: 34px;
+          font-size: 0.72rem;
         }
       }
     </style>
@@ -440,7 +522,7 @@ const vibes = await Promise.all(
             )
           }
           {
-            vibes.map(({ entry, Content, align }, index) => (
+            vibes.map(({ entry, Content, align, imageLayout }, index) => (
               <article
                 class:list={['vibe-item', align, entry.data.size, entry.data.type]}
                 style={`--vibe-index: ${index}`}
@@ -462,9 +544,23 @@ const vibes = await Promise.all(
                 {entry.data.title && <h2 class="vibe-heading">{entry.data.title}</h2>}
 
                 {entry.data.images.length > 0 && (
-                  <div class="vibe-images" aria-label={`${entry.data.title ?? entry.id} images`}>
-                    {entry.data.images.map((image) => (
-                      <figure class="vibe-image">
+                  <div
+                    class:list={['vibe-images', imageLayout.isCollapsible && 'is-collapsible']}
+                    style={`--vibe-image-columns: ${imageLayout.columns}; --vibe-image-visible-rows: ${imageLayout.visibleRows};`}
+                    data-vibe-image-group
+                    data-vibe-image-count={imageLayout.count}
+                    data-vibe-image-columns={imageLayout.columns}
+                    aria-label={`${entry.data.title ?? entry.id} images`}
+                  >
+                    {entry.data.images.map((image, imageIndex) => (
+                      <figure
+                        class:list={[
+                          'vibe-image',
+                          imageLayout.isCollapsible &&
+                            imageIndex >= imageLayout.visibleCount &&
+                            'is-extra',
+                        ]}
+                      >
                         <SmartImage
                           src={image}
                           alt=""
@@ -473,6 +569,18 @@ const vibes = await Promise.all(
                         />
                       </figure>
                     ))}
+                    {imageLayout.isCollapsible && (
+                      <button
+                        class="vibe-image-toggle"
+                        type="button"
+                        aria-expanded="false"
+                        data-vibe-image-toggle
+                        data-expand-label={`展开 ${imageLayout.hiddenCount} 张`}
+                        data-collapse-label="收起图片"
+                      >
+                        展开 {imageLayout.hiddenCount} 张
+                      </button>
+                    )}
                   </div>
                 )}
 
@@ -491,5 +599,26 @@ const vibes = await Promise.all(
         <script>import {mountVibeThread} from '../utils/vibe-thread'; mountVibeThread();</script>
       )
     }
+    <script>
+      const mountVibeImageToggles = () => {
+        document
+          .querySelectorAll<HTMLButtonElement>('[data-vibe-image-toggle]')
+          .forEach((button) => {
+            button.addEventListener('click', () => {
+              const group = button.closest<HTMLElement>('[data-vibe-image-group]');
+
+              if (!group) return;
+
+              const isExpanded = group.classList.toggle('is-expanded');
+              button.setAttribute('aria-expanded', String(isExpanded));
+              button.textContent = isExpanded
+                ? (button.dataset.collapseLabel ?? '收起图片')
+                : (button.dataset.expandLabel ?? '展开图片');
+            });
+          });
+      };
+
+      mountVibeImageToggles();
+    </script>
   </body>
 </html>

--- a/src/pages/vibe.astro
+++ b/src/pages/vibe.astro
@@ -666,6 +666,12 @@ const vibes = await Promise.all(
         document
           .querySelectorAll<HTMLButtonElement>('[data-vibe-image-toggle]')
           .forEach((button) => {
+            if (button.dataset.vibeImageToggleBound === 'true') {
+              return;
+            }
+
+            button.dataset.vibeImageToggleBound = 'true';
+
             button.addEventListener('click', () => {
               const group = button.closest<HTMLElement>('[data-vibe-image-group]');
 
@@ -680,6 +686,7 @@ const vibes = await Promise.all(
           });
       };
 
+      document.addEventListener('astro:page-load', mountVibeImageToggles);
       mountVibeImageToggles();
     </script>
     <ZoomableImage />

--- a/src/pages/vibe.astro
+++ b/src/pages/vibe.astro
@@ -5,6 +5,7 @@ import Footer from '../components/Footer.astro';
 import FormattedDate from '../components/FormattedDate.astro';
 import SmartImage from '../components/SmartImage.astro';
 import BlogTopNav from '../components/blog/BlogTopNav.astro';
+import ZoomableImage from '../components/mdx/ZoomableImage.astro';
 import { getSiteConfig } from '../data/site';
 import { getVibeImageLayout } from '../utils/vibe-image-layout';
 
@@ -313,12 +314,19 @@ const vibes = await Promise.all(
       }
 
       .vibe-image {
+        position: relative;
         margin: 0;
         overflow: hidden;
         aspect-ratio: 1;
         border-radius: 10px;
+        cursor: zoom-in;
         opacity: 0.94;
         rotate: -0.6deg;
+      }
+
+      .vibe-image:focus-visible {
+        outline: 2px solid color-mix(in srgb, var(--paper-accent) 36%, transparent);
+        outline-offset: 4px;
       }
 
       .vibe-images[data-vibe-image-count='1'] .vibe-image {
@@ -335,6 +343,50 @@ const vibes = await Promise.all(
 
       .vibe-image:nth-child(even) {
         rotate: 0.7deg;
+      }
+
+      .vibe-image::before,
+      .vibe-image::after {
+        position: absolute;
+        z-index: 1;
+        pointer-events: none;
+        opacity: 0;
+        transition:
+          opacity 160ms ease,
+          transform 160ms ease;
+        content: '';
+      }
+
+      .vibe-image::before {
+        inset: 0;
+        background: color-mix(in srgb, var(--paper-ink) 24%, transparent);
+      }
+
+      .vibe-image::after {
+        right: 10px;
+        bottom: 10px;
+        width: 34px;
+        height: 34px;
+        border: 1px solid color-mix(in srgb, var(--paper-surface) 72%, transparent);
+        border-radius: 999px;
+        background-color: color-mix(in srgb, var(--paper-surface) 88%, transparent);
+        background-image: url("data:image/svg+xml,%3Csvg width='18' height='18' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' stroke='%23343c35' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.8'%3E%3Ccircle cx='11' cy='11' r='8'/%3E%3Cpath d='m21 21-4.3-4.3M11 8v6M8 11h6'/%3E%3C/g%3E%3C/svg%3E");
+        background-repeat: no-repeat;
+        background-position: center;
+        box-shadow: 0 8px 20px color-mix(in srgb, var(--paper-ink) 10%, transparent);
+        transform: translateY(2px) scale(0.96);
+      }
+
+      .vibe-image:hover::before,
+      .vibe-image:hover::after,
+      .vibe-image:focus-visible::before,
+      .vibe-image:focus-visible::after {
+        opacity: 1;
+      }
+
+      .vibe-image:hover::after,
+      .vibe-image:focus-visible::after {
+        transform: translateY(0) scale(1);
       }
 
       .vibe-image img {
@@ -481,6 +533,11 @@ const vibes = await Promise.all(
           min-height: 34px;
           font-size: 0.72rem;
         }
+
+        .vibe-image::before,
+        .vibe-image::after {
+          display: none;
+        }
       }
     </style>
   </head>
@@ -560,12 +617,17 @@ const vibes = await Promise.all(
                             imageIndex >= imageLayout.visibleCount &&
                             'is-extra',
                         ]}
+                        data-zoomable-image
+                        role="button"
+                        tabindex="0"
+                        aria-label={`${entry.data.title ?? entry.id} image ${imageIndex + 1}`}
                       >
                         <SmartImage
                           src={image}
                           alt=""
                           widths={[360, 520, 720]}
                           sizes="(max-width: 720px) 100vw, 420px"
+                          data-zoomable-image-target
                         />
                       </figure>
                     ))}
@@ -620,5 +682,6 @@ const vibes = await Promise.all(
 
       mountVibeImageToggles();
     </script>
+    <ZoomableImage />
   </body>
 </html>

--- a/src/pages/vibe.astro
+++ b/src/pages/vibe.astro
@@ -603,7 +603,7 @@ const vibes = await Promise.all(
                 {entry.data.images.length > 0 && (
                   <div
                     class:list={['vibe-images', imageLayout.isCollapsible && 'is-collapsible']}
-                    style={`--vibe-image-columns: ${imageLayout.columns}; --vibe-image-visible-rows: ${imageLayout.visibleRows};`}
+                    style={`--vibe-image-columns: ${imageLayout.columns};`}
                     data-vibe-image-group
                     data-vibe-image-count={imageLayout.count}
                     data-vibe-image-columns={imageLayout.columns}

--- a/src/utils/vibe-image-layout.ts
+++ b/src/utils/vibe-image-layout.ts
@@ -1,0 +1,43 @@
+export type VibeImageLayout = {
+  count: number;
+  columns: number;
+  rows: number;
+  visibleRows: number;
+  visibleCount: number;
+  hiddenCount: number;
+  isCollapsible: boolean;
+};
+
+const MAX_COLUMNS = 4;
+const MAX_VISIBLE_ROWS = 4;
+
+export function getVibeImageLayout(imageCount: number): VibeImageLayout {
+  const count = Math.max(0, Math.floor(imageCount));
+
+  if (count === 0) {
+    return {
+      count,
+      columns: 0,
+      rows: 0,
+      visibleRows: 0,
+      visibleCount: 0,
+      hiddenCount: 0,
+      isCollapsible: false,
+    };
+  }
+
+  const columns = count <= 3 ? count : Math.min(MAX_COLUMNS, Math.ceil(Math.sqrt(count)));
+  const rows = Math.ceil(count / columns);
+  const visibleRows = Math.min(rows, MAX_VISIBLE_ROWS);
+  const visibleCount = Math.min(count, visibleRows * columns);
+
+  return {
+    count,
+    columns,
+    rows,
+    visibleRows,
+    visibleCount,
+    hiddenCount: count - visibleCount,
+    isCollapsible: rows > MAX_VISIBLE_ROWS,
+  };
+}


### PR DESCRIPTION
## Summary

- Add a `getVibeImageLayout` utility for count-based `/vibe` image grid layouts.
- Replace the loose flex-wrapped vibe image cluster with a calm, count-aware grid.
- Add lightweight expand/collapse behavior for image groups that exceed four rows.

## Details

This keeps the original `images` order from frontmatter while choosing a rectangle-like layout:

- 2 images: 1x2
- 3 images: 1x3
- 4 images: 2x2
- 5-6 images: 2x3
- 7-9 images: 3x3
- 10-12 images: 3x4
- 13-16 images: 4x4
- 17+ images: capped at 4 columns and collapsed to the first 4 rows by default

The expand/collapse control is a small text button with `aria-expanded`, keeping the `/vibe` page quiet and editorial instead of turning it into a heavy gallery UI.

## Validation

- `bunx tsc --noEmit --strict --ignoreConfig --lib dom,es2022 src\utils\vibe-image-layout.ts`
- Layout table assertion script for the expected image counts
- `bun run build`
- Commit hook ran staged `bun run format:check` and build successfully