### PR TITLE
[codex] Upgrade article TOC tree

### DIFF
--- a/src/components/blog/BlogTopNav.astro
+++ b/src/components/blog/BlogTopNav.astro
@@ -1,11 +1,13 @@
 ---
 import { Github, ListTree, Menu, Moon, Sun } from 'lucide-astro';
 import SiteSearch from './SiteSearch.astro';
+import TocTree from './TocTree.astro';
 import { getSiteConfig } from '../../data/site';
+import type { TocItem } from '../../utils/toc-tree';
 
 interface Props {
   showTocIcon?: boolean;
-  tocItems?: { href: string; label: string }[];
+  tocItems?: TocItem[];
 }
 
 const { showTocIcon = false, tocItems = [] } = Astro.props;
@@ -161,18 +163,10 @@ const shouldShowTocAction = showTocIcon && tocItems.length > 0;
         aria-label="Article table of contents"
         data-nav-toc-menu
         data-toc-root
+        data-toc-scroll
       >
         <p>Table of contents</p>
-        <ol>
-          {tocItems.map((item, index) => (
-            <li>
-              <a href={item.href} data-nav-toc-link data-toc-link data-toc-hash={item.href}>
-                <span>{index + 1}</span>
-                {item.label}
-              </a>
-            </li>
-          ))}
-        </ol>
+        <TocTree items={tocItems} idPrefix="nav-toc" navLink />
       </nav>
     )
   }
@@ -596,41 +590,6 @@ const shouldShowTocAction = showTocIcon && tocItems.length > 0;
       font-weight: 700;
       line-height: 1.2;
       text-transform: uppercase;
-    }
-
-    .mobile-toc-panel ol {
-      display: grid;
-      gap: 4px;
-      margin: 0;
-      padding: 0;
-      list-style: none;
-    }
-
-    .mobile-toc-panel a {
-      display: grid;
-      grid-template-columns: 22px minmax(0, 1fr);
-      gap: 8px;
-      align-items: center;
-      min-height: 36px;
-      padding: 8px 10px;
-      border-radius: 7px;
-      color: var(--paper-ink-soft);
-      font-size: 0.86rem;
-      line-height: 1.35;
-    }
-
-    .mobile-toc-panel a:hover,
-    .mobile-toc-panel a[aria-current='true'],
-    .mobile-toc-panel a[data-state='active'] {
-      background: var(--paper-control-hover);
-      color: var(--paper-accent);
-    }
-
-    .mobile-toc-panel span {
-      color: var(--paper-ink-faint);
-      font-family: var(--font-ui-label);
-      font-size: 0.72rem;
-      font-weight: 700;
     }
   }
 

--- a/src/components/blog/TableOfContents.astro
+++ b/src/components/blog/TableOfContents.astro
@@ -1,32 +1,20 @@
 ---
-interface Item {
-  href: string;
-  label: string;
-}
+import TocTree from './TocTree.astro';
+import { countTocItems, type TocItem } from '../../utils/toc-tree';
 
 interface Props {
-  items: Item[];
+  items: TocItem[];
   compact?: boolean;
   collapsible?: boolean;
   font?: 'ui' | 'article';
 }
 
 const { items, compact = false, collapsible = false, font = 'ui' } = Astro.props;
-import { normalizeHash } from '../../utils/toc-hash';
-
-const normalizedItems = items.map((item) => {
-  const normalizedHref = normalizeHash(item.href) || item.href;
-
-  return {
-    ...item,
-    href: normalizedHref,
-    normalizedHref,
-  };
-});
 
 const hasItems = items.length > 0;
-const canCollapse = collapsible && items.length > 3;
+const canCollapse = collapsible && countTocItems(items) > 3;
 const listId = collapsible ? 'mobile-article-toc-list' : undefined;
+const treeIdPrefix = collapsible ? 'article-toc' : 'sidebar-toc';
 ---
 
 {
@@ -40,16 +28,9 @@ const listId = collapsible ? 'mobile-article-toc-list' : undefined;
       data-expanded={collapsible ? 'false' : undefined}
     >
       <h2>Table of contents</h2>
-      <ol id={listId}>
-        {normalizedItems.map((item, index) => (
-          <li>
-            <a href={item.href} data-toc-link data-toc-hash={item.normalizedHref}>
-              <span>{index + 1}</span>
-              {item.label}
-            </a>
-          </li>
-        ))}
-      </ol>
+      <div id={listId} class="toc-list-wrap" data-toc-scroll>
+        <TocTree items={items} idPrefix={treeIdPrefix} />
+      </div>
       {canCollapse && (
         <button
           class="toc-expand"
@@ -74,14 +55,14 @@ const listId = collapsible ? 'mobile-article-toc-list' : undefined;
 
   const initMobileTocToggle = () => {
     for (const toc of document.querySelectorAll<HTMLElement>('[data-mobile-toc]')) {
-      const button = toc.querySelector<HTMLButtonElement>('[data-toc-expand]');
+      const button = toc.querySelector<HTMLButtonElement>(':scope > [data-toc-expand]');
       const label = toc.querySelector<HTMLElement>('[data-expand-label]');
 
-      if (!button || button.dataset.tocToggleReady) {
+      if (!button || button.dataset.tocExpandReady) {
         continue;
       }
 
-      button.dataset.tocToggleReady = 'true';
+      button.dataset.tocExpandReady = 'true';
       button.addEventListener('click', () => {
         const expanded = toc.dataset.expanded === 'true';
         const nextExpanded = !expanded;
@@ -120,166 +101,6 @@ const listId = collapsible ? 'mobile-article-toc-list' : undefined;
     text-transform: uppercase;
   }
 
-  ol {
-    display: grid;
-    gap: 5px;
-    margin: 0;
-    padding: 0;
-    list-style: none;
-  }
-
-  li {
-    position: relative;
-    --toc-line-x: 4px;
-    --toc-dot-size: 7px;
-    --toc-dot-border: 2px;
-    padding-left: 14px;
-  }
-
-  li::before {
-    position: absolute;
-    top: 0;
-    bottom: -5px;
-    left: var(--toc-line-x);
-    width: 1px;
-    background: rgba(102, 125, 109, 0.16);
-    content: '';
-  }
-
-  li:last-child::before {
-    display: none;
-  }
-
-  a {
-    position: relative;
-    display: grid;
-    grid-template-columns: 22px 1fr;
-    gap: 8px;
-    align-items: center;
-    padding: 9px 10px;
-    border-radius: 7px;
-    color: var(--paper-ink-soft);
-    font-family: var(--font-serif-cn);
-    font-size: 0.86rem;
-    line-height: 1.35;
-    text-decoration: none;
-    transition:
-      background-color 160ms ease,
-      color 160ms ease;
-  }
-
-  .toc-card[data-font='article'] a {
-    font-family: var(--font-article);
-  }
-
-  a[data-state='past'] {
-    color: var(--paper-ink-faint);
-    opacity: 0.62;
-  }
-
-  a[data-state='past'] span {
-    color: var(--paper-ink-faint);
-    opacity: 0.58;
-  }
-
-  a[data-state='future'] {
-    color: var(--paper-ink-soft);
-    opacity: 1;
-  }
-
-  a[data-state='future'] span {
-    color: var(--paper-ink-faint);
-  }
-
-  a::before {
-    position: absolute;
-    left: calc(
-      (var(--toc-line-x) - 14px) - ((var(--toc-dot-size) + var(--toc-dot-border) * 2) / 2)
-    );
-    width: var(--toc-dot-size);
-    height: var(--toc-dot-size);
-    border: var(--toc-dot-border) solid rgba(102, 125, 109, 0.38);
-    border-radius: 50%;
-    background: var(--paper-surface);
-    content: '';
-  }
-
-  a::after {
-    position: absolute;
-    top: 50%;
-    left: calc(var(--toc-line-x) - 14px);
-    transform: translate(-50%, -50%) scale(0.7);
-    opacity: 0;
-    color: var(--paper-surface);
-    content: '✓';
-    font-size: 0.56rem;
-    font-weight: 900;
-    line-height: 1;
-    transition:
-      opacity 160ms ease,
-      transform 160ms ease,
-      color 160ms ease;
-  }
-
-  a[data-state='active'],
-  a[aria-current='true'] {
-    background: rgba(102, 125, 109, 0.24);
-    color: var(--paper-accent);
-  }
-
-  a[data-state]:not([data-state='active']):not([aria-current='true']):hover {
-    background: rgba(102, 125, 109, 0.14);
-    color: var(--paper-accent);
-  }
-
-  a[data-state='active']::before,
-  a[aria-current='true']::before {
-    border-color: var(--paper-accent);
-    background: var(--paper-accent);
-    box-shadow:
-      0 0 0 1px rgba(255, 255, 255, 0.24) inset,
-      0 0 0 3px rgba(102, 125, 109, 0.08);
-  }
-
-  a[data-state]:not([data-state='active']):not([aria-current='true']):hover::before {
-    border-color: rgba(102, 125, 109, 0.58);
-    background: rgba(102, 125, 109, 0.18);
-    box-shadow: none;
-  }
-
-  a[data-state='active']::after,
-  a[aria-current='true']::after {
-    opacity: 1;
-    transform: translate(-50%, -50%) scale(1);
-  }
-
-  a[data-state='active'],
-  a[aria-current='true'] {
-    box-shadow: inset 2px 0 0 var(--paper-accent);
-  }
-
-  a[data-state='past']:not([aria-current='true']) {
-    background: transparent;
-  }
-
-  a[data-state='past']:not([aria-current='true'])::before {
-    border-color: rgba(102, 125, 109, 0.26);
-    background: rgba(102, 125, 109, 0.12);
-    box-shadow: none;
-  }
-
-  a[data-state='future']:not([aria-current='true'])::before {
-    border-color: rgba(102, 125, 109, 0.38);
-    background: var(--paper-surface);
-  }
-
-  span {
-    color: var(--paper-ink-faint);
-    font-family: var(--font-ui-label);
-    font-size: 0.75rem;
-    font-weight: 700;
-  }
-
   .compact {
     padding: 18px;
   }
@@ -295,16 +116,6 @@ const listId = collapsible ? 'mobile-article-toc-list' : undefined;
       background: var(--paper-surface);
       box-shadow: var(--paper-shadow);
       scroll-margin-top: 78px;
-    }
-
-    .can-collapse ol {
-      max-height: 129px;
-      overflow: hidden;
-      transition: max-height 180ms ease;
-    }
-
-    .can-collapse[data-expanded='true'] ol {
-      max-height: none;
     }
 
     .can-collapse .toc-expand {
@@ -348,7 +159,6 @@ const listId = collapsible ? 'mobile-article-toc-list' : undefined;
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .collapsible ol,
     .toc-expand i {
       transition: none;
     }

--- a/src/components/blog/TocTree.astro
+++ b/src/components/blog/TocTree.astro
@@ -1,0 +1,257 @@
+---
+import TocTree from './TocTree.astro';
+import type { TocItem } from '../../utils/toc-tree';
+import { normalizeHash } from '../../utils/toc-hash';
+
+interface Props {
+  items: TocItem[];
+  level?: number;
+  path?: string;
+  idPrefix?: string;
+  navLink?: boolean;
+}
+
+const { items, level = 1, path = '', idPrefix = 'toc', navLink = false } = Astro.props;
+---
+
+<ol class:list={['toc-tree', { 'toc-tree-nested': level > 1 }]}>
+  {
+    items.map((item, index) => {
+      const normalizedHref = normalizeHash(item.href) || item.href;
+      const branchKey = path ? `${path}-${index + 1}` : `${index + 1}`;
+      const branchId = `${idPrefix}-${branchKey}-children`;
+      const numberLabel = branchKey.replaceAll('-', '.');
+      const hasChildren = item.children.length > 0;
+
+      return (
+        <li
+          class:list={['toc-tree-item', { 'has-children': hasChildren }]}
+          data-toc-expanded={hasChildren ? 'false' : undefined}
+        >
+          <div class="toc-row">
+            {hasChildren ? (
+              <button
+                class="toc-branch-toggle"
+                type="button"
+                aria-label="Expand section"
+                aria-expanded="false"
+                aria-controls={branchId}
+                data-toc-toggle
+              >
+                <i aria-hidden="true" />
+              </button>
+            ) : (
+              <span class="toc-branch-spacer" aria-hidden="true" />
+            )}
+            <a
+              href={normalizedHref}
+              data-nav-toc-link={navLink ? '' : undefined}
+              data-toc-link
+              data-toc-hash={normalizedHref}
+            >
+              <span>{numberLabel}</span>
+              {item.label}
+            </a>
+          </div>
+          {hasChildren && (
+            <div class="toc-children" id={branchId} data-toc-branch>
+              <TocTree
+                items={item.children}
+                level={level + 1}
+                path={branchKey}
+                idPrefix={idPrefix}
+                navLink={navLink}
+              />
+            </div>
+          )}
+        </li>
+      );
+    })
+  }
+</ol>
+
+<style is:global>
+  .toc-tree {
+    display: grid;
+    gap: 5px;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .toc-card .toc-list-wrap {
+    max-height: calc(100vh - 140px);
+    overflow-y: auto;
+    padding-right: 4px;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(102, 125, 109, 0.24) transparent;
+  }
+
+  .toc-card.collapsible .toc-list-wrap {
+    max-height: none;
+    overflow: hidden;
+    padding-right: 0;
+  }
+
+  .toc-tree-nested {
+    gap: 4px;
+    padding-top: 4px;
+    padding-left: 13px;
+    border-left: 1px solid rgba(102, 125, 109, 0.14);
+  }
+
+  .toc-tree-item {
+    position: relative;
+  }
+
+  .toc-row {
+    display: grid;
+    grid-template-columns: 18px minmax(0, 1fr);
+    gap: 2px;
+    align-items: start;
+  }
+
+  .toc-branch-toggle,
+  .toc-branch-spacer {
+    width: 18px;
+    height: 36px;
+  }
+
+  .toc-branch-toggle {
+    display: inline-grid;
+    place-items: center;
+    padding: 0;
+    border: 0;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--paper-ink-faint);
+    cursor: pointer;
+    transition:
+      background-color 160ms ease,
+      color 160ms ease;
+  }
+
+  .toc-branch-toggle:hover,
+  .toc-branch-toggle:focus-visible {
+    background: rgba(102, 125, 109, 0.1);
+    color: var(--paper-accent);
+  }
+
+  .toc-branch-toggle i {
+    width: 7px;
+    height: 7px;
+    border-right: 1.5px solid currentColor;
+    border-bottom: 1.5px solid currentColor;
+    transform: translateX(-1px) rotate(-45deg);
+    transition: transform 160ms ease;
+  }
+
+  .toc-tree-item[data-toc-expanded='true'] > .toc-row .toc-branch-toggle i {
+    transform: translateY(-1px) rotate(45deg);
+  }
+
+  .toc-tree-item[data-toc-expanded='false'] > .toc-children {
+    display: none;
+  }
+
+  .toc-card .toc-tree a,
+  .mobile-toc-panel .toc-tree a {
+    display: grid;
+    grid-template-columns: 28px minmax(0, 1fr);
+    gap: 8px;
+    align-items: center;
+    min-width: 0;
+    min-height: 36px;
+    padding: 8px 10px;
+    border-radius: 7px;
+    color: var(--paper-ink-soft);
+    font-family: var(--font-serif-cn);
+    font-size: 0.84rem;
+    line-height: 1.35;
+    text-decoration: none;
+    transition:
+      background-color 160ms ease,
+      color 160ms ease,
+      opacity 160ms ease;
+  }
+
+  .toc-card[data-font='article'] .toc-tree a {
+    font-family: var(--font-article);
+  }
+
+  .toc-card .toc-tree a > span,
+  .mobile-toc-panel .toc-tree a > span {
+    color: var(--paper-ink-faint);
+    font-family: var(--font-ui-label);
+    font-size: 0.7rem;
+    font-weight: 700;
+  }
+
+  .toc-card .toc-tree a[data-state='past'],
+  .mobile-toc-panel .toc-tree a[data-state='past'] {
+    color: var(--paper-ink-faint);
+    opacity: 0.62;
+  }
+
+  .toc-card .toc-tree a[data-state='future'],
+  .mobile-toc-panel .toc-tree a[data-state='future'] {
+    color: var(--paper-ink-soft);
+    opacity: 1;
+  }
+
+  .toc-card .toc-tree a[data-state='active'],
+  .toc-card .toc-tree a[aria-current='true'],
+  .mobile-toc-panel .toc-tree a[data-state='active'],
+  .mobile-toc-panel .toc-tree a[aria-current='true'] {
+    background: rgba(102, 125, 109, 0.16);
+    color: var(--paper-accent);
+    box-shadow: inset 2px 0 0 rgba(102, 125, 109, 0.5);
+  }
+
+  .toc-card .toc-tree a[data-state]:not([data-state='active']):not([aria-current='true']):hover,
+  .mobile-toc-panel
+    .toc-tree
+    a[data-state]:not([data-state='active']):not([aria-current='true']):hover {
+    background: rgba(102, 125, 109, 0.1);
+    color: var(--paper-accent);
+  }
+
+  @media (max-width: 900px) {
+    .toc-card .toc-list-wrap {
+      max-height: none;
+      overflow: hidden;
+      padding-right: 0;
+    }
+
+    .toc-card.can-collapse .toc-list-wrap {
+      max-height: 132px;
+      transition: max-height 180ms ease;
+    }
+
+    .toc-card.can-collapse[data-expanded='true'] .toc-list-wrap {
+      max-height: none;
+    }
+
+    .toc-tree-nested {
+      padding-left: 9px;
+    }
+
+    .toc-card .toc-tree a,
+    .mobile-toc-panel .toc-tree a {
+      grid-template-columns: 24px minmax(0, 1fr);
+      min-height: 38px;
+      padding: 8px;
+      font-size: 0.82rem;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .toc-card.can-collapse .toc-list-wrap,
+    .toc-branch-toggle,
+    .toc-branch-toggle i,
+    .toc-card .toc-tree a,
+    .mobile-toc-panel .toc-tree a {
+      transition: none;
+    }
+  }
+</style>

--- a/src/components/blog/TocTree.astro
+++ b/src/components/blog/TocTree.astro
@@ -20,7 +20,7 @@ const { items, level = 1, path = '', idPrefix = 'toc', navLink = false } = Astro
       const normalizedHref = normalizeHash(item.href) || item.href;
       const branchKey = path ? `${path}-${index + 1}` : `${index + 1}`;
       const branchId = `${idPrefix}-${branchKey}-children`;
-      const numberLabel = branchKey.replaceAll('-', '.');
+      const numberLabel = branchKey.replace(/-/g, '.');
       const hasChildren = item.children.length > 0;
 
       return (

--- a/src/layouts/BlogArticle.astro
+++ b/src/layouts/BlogArticle.astro
@@ -10,6 +10,7 @@ import { getThemePalette, getSiteConfig } from '../data/site';
 import { resolveCommentsConfig } from '../utils/comments';
 import { sortByDateDesc } from '../utils/content-dates';
 import { getSeriesContext, slugifyGroupName } from '../utils/content-groups';
+import { buildTocTree, countTocItems } from '../utils/toc-tree';
 
 const { comments: rawComments } = await getSiteConfig();
 const comments = resolveCommentsConfig(rawComments);
@@ -91,10 +92,8 @@ const categoryLinks = (post.data.categories ?? []).map((name) => ({
   slug: slugifyGroupName(name),
 }));
 const rawSeries = post.data.series ?? [];
-const renderedTocItems = headings
-  .filter((heading) => heading.depth === 2 || heading.depth === 3)
-  .map((heading) => ({ href: `#${heading.slug}`, label: heading.text }));
-const tocItems = renderedTocItems;
+const tocItems = buildTocTree(headings);
+const tocItemCount = countTocItems(tocItems);
 const sidebarConfig = {
   enable: true,
   toc: true,
@@ -104,7 +103,7 @@ const sidebarConfig = {
 };
 const shouldRenderSidebar = sidebarConfig.enable ?? true;
 const shouldRenderToc = sidebarConfig.toc ?? true;
-const hasToc = shouldRenderToc && tocItems.length > 0;
+const hasToc = shouldRenderToc && tocItemCount > 0;
 
 const allBlogPosts = await getCollection('blog', ({ data }) => !data.draft);
 const currentBlogPost = isBlogPost ? (post as CollectionEntry<'blog'>) : undefined;

--- a/src/utils/toc-spy.ts
+++ b/src/utils/toc-spy.ts
@@ -179,11 +179,6 @@ const initBranchToggles = (signal: AbortSignal): void => {
       'click',
       () => {
         const expanded = item.dataset.tocExpanded === 'true';
-        const hasActiveChild = Boolean(item.querySelector('[data-toc-link][aria-current="true"]'));
-
-        if (expanded && hasActiveChild) {
-          return;
-        }
 
         setBranchExpanded(item, !expanded);
       },

--- a/src/utils/toc-spy.ts
+++ b/src/utils/toc-spy.ts
@@ -41,11 +41,54 @@ const getSectionFromHash = (hash: string): HTMLElement | null => {
   const normalizedId = normalizedHash.slice(1);
   const articleHeadings = Array.from(
     document.querySelectorAll<HTMLElement>(
-      '.article-content h1[id], .article-content h2[id], .article-content h3[id]',
+      '.article-content h2[id], .article-content h3[id], .article-content h4[id], .article-content h5[id], .article-content h6[id]',
     ),
   );
 
   return articleHeadings.find((heading) => normalizeIdValue(heading.id) === normalizedId) ?? null;
+};
+
+const setBranchExpanded = (item: HTMLElement, expanded: boolean): void => {
+  item.dataset.tocExpanded = String(expanded);
+
+  const toggle = item.querySelector<HTMLButtonElement>(':scope > .toc-row [data-toc-toggle]');
+  if (!toggle) {
+    return;
+  }
+
+  toggle.setAttribute('aria-expanded', String(expanded));
+  toggle.setAttribute('aria-label', expanded ? 'Collapse section' : 'Expand section');
+};
+
+const expandLinkAncestors = (link: TocLink): void => {
+  let parent = link.parentElement?.closest<HTMLElement>('.toc-tree-item[data-toc-expanded]');
+
+  while (parent) {
+    setBranchExpanded(parent, true);
+    parent =
+      parent.parentElement?.closest<HTMLElement>('.toc-tree-item[data-toc-expanded]') ?? null;
+  }
+};
+
+const keepLinkVisible = (link: TocLink): void => {
+  const scrollArea = link.closest<HTMLElement>('[data-toc-scroll]');
+  if (!scrollArea || scrollArea.scrollHeight <= scrollArea.clientHeight) {
+    return;
+  }
+
+  const linkRect = link.getBoundingClientRect();
+  const areaRect = scrollArea.getBoundingClientRect();
+  const margin = 12;
+
+  if (linkRect.top >= areaRect.top + margin && linkRect.bottom <= areaRect.bottom - margin) {
+    return;
+  }
+
+  link.scrollIntoView({
+    block: 'nearest',
+    inline: 'nearest',
+    behavior: window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth',
+  });
 };
 
 const getSections = (): HTMLElement[] => {
@@ -100,10 +143,41 @@ const setActiveLink = (activeHash: string): void => {
 
       if (isActive) {
         link.setAttribute('aria-current', 'true');
+        expandLinkAncestors(link);
+        keepLinkVisible(link);
       } else {
         link.removeAttribute('aria-current');
       }
     }
+  }
+};
+
+const initBranchToggles = (signal: AbortSignal): void => {
+  for (const toggle of document.querySelectorAll<HTMLButtonElement>('[data-toc-toggle]')) {
+    if (toggle.dataset.tocToggleReady) {
+      continue;
+    }
+
+    const item = toggle.closest<HTMLElement>('.toc-tree-item[data-toc-expanded]');
+    if (!item) {
+      continue;
+    }
+
+    toggle.dataset.tocToggleReady = 'true';
+    toggle.addEventListener(
+      'click',
+      () => {
+        const expanded = item.dataset.tocExpanded === 'true';
+        const hasActiveChild = Boolean(item.querySelector('[data-toc-link][aria-current="true"]'));
+
+        if (expanded && hasActiveChild) {
+          return;
+        }
+
+        setBranchExpanded(item, !expanded);
+      },
+      { signal },
+    );
   }
 };
 
@@ -119,6 +193,7 @@ const initNavfolioToc = (): (() => void) | null => {
   let ticking = false;
   let freezeActiveFromScroll = false;
   let observer: IntersectionObserver | null = null;
+  initBranchToggles(signal);
 
   const setActiveByHash = (hash: string): boolean => {
     const section = getSectionFromHash(hash);
@@ -233,13 +308,16 @@ const initNavfolioToc = (): (() => void) | null => {
         event.preventDefault();
         history.pushState(null, '', normalizedHash);
         freezeActiveFromScroll = true;
+        expandLinkAncestors(link);
         scrollToHeading(normalizedHash);
       },
       { signal },
     );
   }
 
-  if ('IntersectionObserver' in window) {
+  const supportsIntersectionObserver = typeof globalThis.IntersectionObserver === 'function';
+
+  if (supportsIntersectionObserver) {
     observer = new IntersectionObserver(
       () => {
         scheduleUpdateActiveSection();
@@ -254,6 +332,8 @@ const initNavfolioToc = (): (() => void) | null => {
     for (const section of sections) {
       observer.observe(section);
     }
+  } else {
+    window.addEventListener('scroll', scheduleUpdateActiveSection, { passive: true, signal });
   }
 
   const onPopstate = () => {
@@ -271,7 +351,6 @@ const initNavfolioToc = (): (() => void) | null => {
     }
   };
 
-  window.addEventListener('scroll', scheduleUpdateActiveSection, { passive: true, signal });
   window.addEventListener('resize', scheduleUpdateActiveSection, { passive: true, signal });
   window.addEventListener('wheel', unlockActiveFromScroll, { passive: true, signal });
   window.addEventListener('touchstart', unlockActiveFromScroll, { passive: true, signal });

--- a/src/utils/toc-spy.ts
+++ b/src/utils/toc-spy.ts
@@ -76,19 +76,30 @@ const keepLinkVisible = (link: TocLink): void => {
     return;
   }
 
-  const linkRect = link.getBoundingClientRect();
-  const areaRect = scrollArea.getBoundingClientRect();
-  const margin = 12;
-
-  if (linkRect.top >= areaRect.top + margin && linkRect.bottom <= areaRect.bottom - margin) {
+  const style = window.getComputedStyle(scrollArea);
+  if (style.display === 'none' || style.opacity === '0' || style.visibility === 'hidden') {
     return;
   }
 
-  link.scrollIntoView({
-    block: 'nearest',
-    inline: 'nearest',
-    behavior: window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth',
-  });
+  const linkRect = link.getBoundingClientRect();
+  const areaRect = scrollArea.getBoundingClientRect();
+  const margin = 12;
+  const relativeTop = linkRect.top - areaRect.top + scrollArea.scrollTop;
+  const relativeBottom = relativeTop + linkRect.height;
+  let targetScrollTop = scrollArea.scrollTop;
+
+  if (relativeTop < scrollArea.scrollTop + margin) {
+    targetScrollTop = relativeTop - margin;
+  } else if (relativeBottom > scrollArea.scrollTop + scrollArea.clientHeight - margin) {
+    targetScrollTop = relativeBottom - scrollArea.clientHeight + margin;
+  }
+
+  if (targetScrollTop !== scrollArea.scrollTop) {
+    scrollArea.scrollTo({
+      top: targetScrollTop,
+      behavior: window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth',
+    });
+  }
 };
 
 const getSections = (): HTMLElement[] => {

--- a/src/utils/toc-spy.ts
+++ b/src/utils/toc-spy.ts
@@ -321,7 +321,7 @@ const initNavfolioToc = (): (() => void) | null => {
     );
   }
 
-  const supportsIntersectionObserver = typeof globalThis.IntersectionObserver === 'function';
+  const supportsIntersectionObserver = typeof IntersectionObserver === 'function';
 
   if (supportsIntersectionObserver) {
     observer = new IntersectionObserver(

--- a/src/utils/toc-tree.ts
+++ b/src/utils/toc-tree.ts
@@ -1,0 +1,48 @@
+export interface TocHeading {
+  depth: number;
+  slug: string;
+  text: string;
+}
+
+export interface TocItem {
+  href: string;
+  label: string;
+  depth: number;
+  children: TocItem[];
+}
+
+export const buildTocTree = (headings: TocHeading[], minDepth = 2, maxDepth = 6): TocItem[] => {
+  const roots: TocItem[] = [];
+  const stack: TocItem[] = [];
+
+  for (const heading of headings) {
+    if (heading.depth < minDepth || heading.depth > maxDepth) {
+      continue;
+    }
+
+    const item: TocItem = {
+      href: `#${heading.slug}`,
+      label: heading.text,
+      depth: heading.depth,
+      children: [],
+    };
+
+    while (stack.length > 0 && stack[stack.length - 1].depth >= item.depth) {
+      stack.pop();
+    }
+
+    const parent = stack.at(-1);
+    if (parent) {
+      parent.children.push(item);
+    } else {
+      roots.push(item);
+    }
+
+    stack.push(item);
+  }
+
+  return roots;
+};
+
+export const countTocItems = (items: TocItem[]): number =>
+  items.reduce((count, item) => count + 1 + countTocItems(item.children), 0);


### PR DESCRIPTION
## Summary

- Build a nested article TOC tree from Astro headings, including h2 through h6.
- Reuse one recursive TOC renderer across the sidebar, in-article mobile TOC, and top-nav mobile TOC.
- Add accessible expand/collapse controls, constrained sidebar scrolling, active branch expansion, and active-link visibility syncing.
- Keep existing hash normalization and heading candidate lookup behavior while refining TOC spy updates to use IntersectionObserver as the primary active-state trigger.

## Review notes

During review, I fixed a duplicate branch id issue so each TOC mount has unique `aria-controls` targets.

## Validation

- `bun run format:check`
- `bunx tsc --ignoreConfig --noEmit --strict --lib dom,es2022 src\utils\toc-tree.ts src\utils\toc-spy.ts`
- `bun run build`
- TOC tree builder smoke check with h2-h6 sample headings

Build still reports the existing warning that `src/content/vibe/` does not exist; this is unrelated to the TOC changes.

close #61 