### PR TITLE
feat: add tag archive pages

### DIFF
--- a/src/components/article/ArticleHeader.astro
+++ b/src/components/article/ArticleHeader.astro
@@ -3,6 +3,9 @@ import SmartImage from '../SmartImage.astro';
 import PageView from '../comments/PageView.astro';
 import FormattedDate from '../FormattedDate.astro';
 import Icon from '../Icon.astro';
+import { slugifyGroupName } from '../../utils/content-groups';
+
+type TagLink = string | { name: string; slug: string };
 
 interface Props {
   title: string;
@@ -10,7 +13,7 @@ interface Props {
   date?: Date;
   wordCount: number;
   readingTime: string;
-  tags?: string[];
+  tags?: TagLink[];
   categories?: { name: string; slug: string }[];
   series?: { name: string; slug: string; current?: number; total?: number }[];
   heroImage?: ImageMetadata | string;
@@ -38,7 +41,10 @@ const {
   showPageView = false,
 } = Astro.props;
 const wordCountLabel = `${wordCount.toLocaleString('en-US')} words`;
-const hasTags = tags.length > 0;
+const tagLinks = tags.map((tag) =>
+  typeof tag === 'string' ? { name: tag, slug: slugifyGroupName(tag) } : tag,
+);
+const hasTags = tagLinks.length > 0;
 const hasCategories = categories.length > 0;
 const hasSeries = series.length > 0;
 const hasGroups = hasCategories || hasSeries;
@@ -71,8 +77,10 @@ const basePath = import.meta.env.BASE_URL.replace(/\/$/, '');
             {showPageView && <PageView pathname={pathname} />}
             {hasTags && (
               <span class="meta-item tag-list">
-                {tags.map((tag) => (
-                  <span class="tag">#{tag}</span>
+                {tagLinks.map((tag) => (
+                  <a class="tag" href={`${basePath}/tags/${tag.slug}/`}>
+                    #{tag.name}
+                  </a>
                 ))}
               </span>
             )}
@@ -126,8 +134,10 @@ const basePath = import.meta.env.BASE_URL.replace(/\/$/, '');
           {showPageView && <PageView pathname={pathname} />}
           {hasTags && (
             <span class="meta-item tag-list">
-              {tags.map((tag) => (
-                <span class="tag">#{tag}</span>
+              {tagLinks.map((tag) => (
+                <a class="tag" href={`${basePath}/tags/${tag.slug}/`}>
+                  #{tag.name}
+                </a>
               ))}
             </span>
           )}
@@ -244,6 +254,19 @@ const basePath = import.meta.env.BASE_URL.replace(/\/$/, '');
     color: var(--paper-accent);
     font-family: var(--font-serif-cn);
     font-weight: 700;
+    text-decoration: none;
+    transition: color 180ms ease;
+  }
+
+  .tag:hover {
+    color: var(--paper-ink);
+  }
+
+  .tag:focus-visible,
+  .group-link:focus-visible {
+    border-radius: 4px;
+    outline: 2px solid var(--paper-line-strong);
+    outline-offset: 3px;
   }
 
   .group-meta-line {

--- a/src/components/blog/BackLink.astro
+++ b/src/components/blog/BackLink.astro
@@ -11,10 +11,44 @@ const basePath = import.meta.env.BASE_URL.replace(/\/$/, '');
 const linkHref = `${basePath}${href.startsWith('/') ? href : `/${href}`}`;
 ---
 
-<a class="back-link" href={linkHref}>
+<a class="back-link" href={linkHref} data-back-link>
   <ArrowLeft size={15} strokeWidth={2} aria-hidden="true" />
   <span>{label}</span>
 </a>
+
+<script>
+  const navfolioWindow = window as Window & { __navfolioBackLinkInitialized?: boolean };
+
+  if (!navfolioWindow.__navfolioBackLinkInitialized) {
+    navfolioWindow.__navfolioBackLinkInitialized = true;
+
+    document.addEventListener('click', (event) => {
+      const link =
+        event.target instanceof Element ? event.target.closest('[data-back-link]') : null;
+
+      if (!(link instanceof HTMLAnchorElement)) {
+        return;
+      }
+
+      const hasSameOriginReferrer = (() => {
+        if (!document.referrer) {
+          return false;
+        }
+
+        try {
+          return new URL(document.referrer).origin === window.location.origin;
+        } catch {
+          return false;
+        }
+      })();
+
+      if (hasSameOriginReferrer && window.history.length > 1) {
+        event.preventDefault();
+        window.history.back();
+      }
+    });
+  }
+</script>
 
 <style>
   .back-link {

--- a/src/components/blog/BackLink.astro
+++ b/src/components/blog/BackLink.astro
@@ -23,6 +23,10 @@ const linkHref = `${basePath}${href.startsWith('/') ? href : `/${href}`}`;
     navfolioWindow.__navfolioBackLinkInitialized = true;
 
     document.addEventListener('click', (event) => {
+      if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+        return;
+      }
+
       const link =
         event.target instanceof Element ? event.target.closest('[data-back-link]') : null;
 

--- a/src/components/blog/BlogArchive.astro
+++ b/src/components/blog/BlogArchive.astro
@@ -104,7 +104,9 @@ function getPageHref(pageNumber: number) {
                   {post.data.tags.length > 0 && (
                     <span class="post-tags">
                       {post.data.tags.map((tag) => (
-                        <span class="post-tag">#{tag}</span>
+                        <a class="post-tag" href={withBase(`/tags/${slugifyGroupName(tag)}/`)}>
+                          #{tag}
+                        </a>
                       ))}
                     </span>
                   )}
@@ -282,6 +284,21 @@ function getPageHref(pageNumber: number) {
 
   .post-tag {
     color: var(--paper-accent);
+    text-decoration: none;
+    transition: color 180ms ease;
+  }
+
+  .post-tag:hover {
+    color: var(--paper-ink);
+  }
+
+  .post-tag:focus-visible,
+  .post-group:focus-visible,
+  .title-link:focus-visible,
+  .thumb-wrap:focus-visible {
+    border-radius: 4px;
+    outline: 2px solid var(--paper-line-strong);
+    outline-offset: 3px;
   }
 
   .post-tag + .post-tag::before,

--- a/src/components/blog/BlogArchive.astro
+++ b/src/components/blog/BlogArchive.astro
@@ -101,7 +101,7 @@ function getPageHref(pageNumber: number) {
                       ))}
                     </span>
                   )}
-                  {post.data.tags.length > 0 && (
+                  {post.data.tags && post.data.tags.length > 0 && (
                     <span class="post-tags">
                       {post.data.tags.map((tag) => (
                         <a class="post-tag" href={withBase(`/tags/${slugifyGroupName(tag)}/`)}>

--- a/src/layouts/BlogArticle.astro
+++ b/src/layouts/BlogArticle.astro
@@ -87,6 +87,10 @@ const wordCount = englishWords.length + cjkChars.length;
 const readingMinutes = Math.max(1, Math.ceil(englishWords.length / 220 + cjkChars.length / 500));
 const readingTime = `${readingMinutes} min read`;
 const tags = post.data.tags ?? [];
+const tagLinks = tags.map((name) => ({
+  name,
+  slug: slugifyGroupName(name),
+}));
 const categoryLinks = (post.data.categories ?? []).map((name) => ({
   name,
   slug: slugifyGroupName(name),
@@ -149,7 +153,7 @@ const hasSidebar = shouldRenderSidebar && hasToc;
             date={date}
             wordCount={wordCount}
             readingTime={readingTime}
-            tags={tags}
+            tags={tagLinks}
             categories={categoryLinks}
             series={seriesLinks}
             heroImage={heroImage}

--- a/src/pages/blog/categories/[category].astro
+++ b/src/pages/blog/categories/[category].astro
@@ -60,7 +60,7 @@ const { category, page } = Astro.props;
   <body>
     <BlogTopNav />
     <main data-pagefind-body>
-      <BackLink href="/blog/categories/" label="Back to categories" />
+      <BackLink href="/blog/categories/" label="Back" />
       <BlogArchive
         page={page}
         headerKicker="Category"

--- a/src/pages/blog/categories/index.astro
+++ b/src/pages/blog/categories/index.astro
@@ -59,7 +59,7 @@ const categories = getAllCategories(await getCollection('blog', ({ data }) => !d
   <body>
     <BlogTopNav />
     <main data-pagefind-body>
-      <BackLink href="/blog/" label="Back to blog" />
+      <BackLink href="/blog/" label="Back" />
       <header class="archive-hero archive-header-shared page-header-spacing">
         <div class="archive-header-main">
           <p class="archive-kicker">Browse notes</p>

--- a/src/pages/blog/series/[series].astro
+++ b/src/pages/blog/series/[series].astro
@@ -114,7 +114,7 @@ const basePath = import.meta.env.BASE_URL.replace(/\/$/, '');
   <body>
     <BlogTopNav />
     <main data-pagefind-body>
-      <BackLink href="/blog/series/" label="Back to series" />
+      <BackLink href="/blog/series/" label="Back" />
       <header class="archive-hero archive-header-shared page-header-spacing">
         <div class="archive-header-main series-detail-header">
           <div>

--- a/src/pages/blog/series/index.astro
+++ b/src/pages/blog/series/index.astro
@@ -48,7 +48,7 @@ const series = getAllSeries(await getCollection('blog', ({ data }) => !data.draf
   <body>
     <BlogTopNav />
     <main data-pagefind-body>
-      <BackLink href="/blog/" label="Back to blog" />
+      <BackLink href="/blog/" label="Back" />
       <header class="archive-hero archive-header-shared page-header-spacing">
         <div class="archive-header-main">
           <p class="archive-kicker">Reading paths</p>

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -1,0 +1,73 @@
+---
+import { getCollection } from 'astro:content';
+import BaseHead from '../../components/BaseHead.astro';
+import Footer from '../../components/Footer.astro';
+import BackLink from '../../components/blog/BackLink.astro';
+import BlogArchive from '../../components/blog/BlogArchive.astro';
+import BlogTopNav from '../../components/blog/BlogTopNav.astro';
+import { getSiteConfig } from '../../data/site';
+import { sortByDateDesc } from '../../utils/content-dates';
+import { getAllTags, getPostsByTag } from '../../utils/content-groups';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('blog', ({ data }) => !data.draft);
+
+  return getAllTags(posts).map((tag) => {
+    const tagPosts = sortByDateDesc(getPostsByTag(posts, tag.slug));
+
+    return {
+      params: { tag: tag.slug },
+      props: {
+        tag,
+        page: {
+          data: tagPosts,
+          currentPage: 1,
+          lastPage: 1,
+          total: tagPosts.length,
+          size: tagPosts.length,
+          url: {
+            current: `/tags/${tag.slug}/`,
+          },
+        },
+      },
+    };
+  });
+}
+
+const { site, theme } = await getSiteConfig();
+const palette = theme.palette;
+const { tag, page } = Astro.props;
+---
+
+<!doctype html>
+<html lang="zh-CN" data-palette={palette}>
+  <head>
+    <BaseHead title={`${tag.name} | ${site.title}`} description={site.description} />
+    <style>
+      main {
+        width: min(100%, var(--layout-shell-width));
+        max-width: none;
+        padding: 118px var(--layout-page-gutter) var(--layout-page-bottom);
+      }
+
+      @media (max-width: 720px) {
+        main {
+          padding-top: 88px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <BlogTopNav />
+    <main data-pagefind-body>
+      <BackLink href="/blog/" label="Back" />
+      <BlogArchive
+        page={page}
+        headerKicker="Tag"
+        headerTitle={tag.name}
+        headerNote={`${tag.count} ${tag.count === 1 ? 'article' : 'articles'} with this tag.`}
+      />
+    </main>
+    <Footer />
+  </body>
+</html>

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -7,13 +7,13 @@ import BlogArchive from '../../components/blog/BlogArchive.astro';
 import BlogTopNav from '../../components/blog/BlogTopNav.astro';
 import { getSiteConfig } from '../../data/site';
 import { sortByDateDesc } from '../../utils/content-dates';
-import { getAllTags, getPostsByTag } from '../../utils/content-groups';
+import { getAllTags } from '../../utils/content-groups';
 
 export async function getStaticPaths() {
   const posts = await getCollection('blog', ({ data }) => !data.draft);
 
   return getAllTags(posts).map((tag) => {
-    const tagPosts = sortByDateDesc(getPostsByTag(posts, tag.slug));
+    const tagPosts = sortByDateDesc(tag.posts);
 
     return {
       params: { tag: tag.slug },

--- a/src/utils/content-groups.ts
+++ b/src/utils/content-groups.ts
@@ -30,7 +30,9 @@ function getComparableName(name: string) {
   return name.trim().replace(/\s+/g, ' ').toLocaleLowerCase();
 }
 
-function getGroupItems(post: BlogPost, field: 'categories' | 'series') {
+type GroupField = 'categories' | 'series' | 'tags';
+
+function getGroupItems(post: BlogPost, field: GroupField) {
   const seen = new Set<string>();
 
   return (post.data[field] ?? [])
@@ -73,7 +75,7 @@ export function slugifyGroupName(name: string) {
   return normalized || 'untitled';
 }
 
-function createGroupMap(posts: BlogPost[], field: 'categories' | 'series') {
+function createGroupMap(posts: BlogPost[], field: GroupField) {
   const groups = new Map<string, { name: string; slug: string; posts: BlogPost[] }>();
 
   posts.filter(isPublished).forEach((post) => {
@@ -108,6 +110,24 @@ export function getPostsByCategory(posts: BlogPost[], categorySlug: string) {
     (post) =>
       isPublished(post) &&
       getGroupItems(post, 'categories').some((name) => slugifyGroupName(name) === categorySlug),
+  );
+}
+
+export function getAllTags(posts: BlogPost[]): ContentGroup[] {
+  return [...createGroupMap(posts, 'tags').values()]
+    .map(({ name, slug, posts: groupPosts }) => ({
+      name,
+      slug,
+      count: groupPosts.length,
+    }))
+    .sort((a, b) => b.count - a.count || sortByName(a, b));
+}
+
+export function getPostsByTag(posts: BlogPost[], tagSlug: string) {
+  return posts.filter(
+    (post) =>
+      isPublished(post) &&
+      getGroupItems(post, 'tags').some((name) => slugifyGroupName(name) === tagSlug),
   );
 }
 

--- a/src/utils/content-groups.ts
+++ b/src/utils/content-groups.ts
@@ -12,6 +12,10 @@ export interface SeriesGroup extends ContentGroup {
   posts: BlogPost[];
 }
 
+export interface TagGroup extends ContentGroup {
+  posts: BlogPost[];
+}
+
 export interface SeriesContext {
   name: string;
   slug: string;
@@ -113,11 +117,12 @@ export function getPostsByCategory(posts: BlogPost[], categorySlug: string) {
   );
 }
 
-export function getAllTags(posts: BlogPost[]): ContentGroup[] {
+export function getAllTags(posts: BlogPost[]): TagGroup[] {
   return [...createGroupMap(posts, 'tags').values()]
     .map(({ name, slug, posts: groupPosts }) => ({
       name,
       slug,
+      posts: groupPosts,
       count: groupPosts.length,
     }))
     .sort((a, b) => b.count - a.count || sortByName(a, b));


### PR DESCRIPTION
## Summary

- Add root-level `/tags/[tag]/` archive pages generated from blog post frontmatter tags.
- Make tag metadata clickable in blog archive rows and article headers.
- Reuse existing category/series slug and grouping logic for tag aggregation.
- Update archive back links to use browser history when available, with static fallback links.

## Verification

- `bun run format:check`
- `bun run build`

close #23 