### PR TITLE
feat: add sitewide scroll to top button

### DIFF
--- a/src/components/ScrollToTopButton.astro
+++ b/src/components/ScrollToTopButton.astro
@@ -8,8 +8,6 @@ import { ArrowUp } from 'lucide-astro';
   type="button"
   aria-label="返回顶部"
   title="返回顶部"
-  aria-hidden="true"
-  tabindex="-1"
   data-scroll-top-button
 >
   <ArrowUp size={18} stroke-width={2} aria-hidden="true" focusable="false" />
@@ -52,6 +50,8 @@ import { ArrowUp } from 'lucide-astro';
         button.setAttribute('aria-hidden', String(!visible));
         button.tabIndex = visible ? 0 : -1;
       };
+
+      setVisible(false);
 
       if (marker) {
         const observer = new IntersectionObserver(([entry]) => {

--- a/src/components/ScrollToTopButton.astro
+++ b/src/components/ScrollToTopButton.astro
@@ -16,6 +16,27 @@ import { ArrowUp } from 'lucide-astro';
 </button>
 
 <script>
+  type ScrollToTopState = {
+    lifecycleReady: boolean;
+    observers: Set<IntersectionObserver>;
+  };
+
+  const scrollTopWindow = window as Window & {
+    __navfolioScrollTopState?: ScrollToTopState;
+  };
+  const scrollTopState = (scrollTopWindow.__navfolioScrollTopState ??= {
+    lifecycleReady: false,
+    observers: new Set<IntersectionObserver>(),
+  });
+
+  const disconnectScrollToTopObservers = () => {
+    for (const observer of scrollTopState.observers) {
+      observer.disconnect();
+    }
+
+    scrollTopState.observers.clear();
+  };
+
   const initScrollToTopButton = () => {
     for (const button of document.querySelectorAll<HTMLButtonElement>('[data-scroll-top-button]')) {
       if (button.dataset.scrollTopReady === 'true') {
@@ -38,6 +59,7 @@ import { ArrowUp } from 'lucide-astro';
         });
 
         observer.observe(marker);
+        scrollTopState.observers.add(observer);
       }
 
       button.addEventListener('click', () => {
@@ -50,7 +72,12 @@ import { ArrowUp } from 'lucide-astro';
   };
 
   initScrollToTopButton();
-  document.addEventListener('astro:page-load', initScrollToTopButton);
+
+  if (!scrollTopState.lifecycleReady) {
+    scrollTopState.lifecycleReady = true;
+    document.addEventListener('astro:before-swap', disconnectScrollToTopObservers);
+    document.addEventListener('astro:page-load', initScrollToTopButton);
+  }
 </script>
 
 <style>

--- a/src/components/ScrollToTopButton.astro
+++ b/src/components/ScrollToTopButton.astro
@@ -32,41 +32,20 @@ import { ArrowUp } from 'lucide-astro';
         button.tabIndex = visible ? 0 : -1;
       };
 
-      const shouldShow = () => window.scrollY > window.innerHeight;
-
       if (marker) {
         const observer = new IntersectionObserver(([entry]) => {
           setVisible(entry.boundingClientRect.top < 0 && !entry.isIntersecting);
         });
 
         observer.observe(marker);
-      } else {
-        let frame = 0;
-        const update = () => {
-          frame = 0;
-          setVisible(shouldShow());
-        };
-
-        window.addEventListener(
-          'scroll',
-          () => {
-            if (!frame) {
-              frame = window.requestAnimationFrame(update);
-            }
-          },
-          { passive: true },
-        );
       }
 
-      window.addEventListener('resize', () => setVisible(shouldShow()));
       button.addEventListener('click', () => {
         window.scrollTo({
           top: 0,
           behavior: prefersReducedMotion.matches ? 'auto' : 'smooth',
         });
       });
-
-      setVisible(shouldShow());
     }
   };
 

--- a/src/components/ScrollToTopButton.astro
+++ b/src/components/ScrollToTopButton.astro
@@ -1,0 +1,147 @@
+---
+import { ArrowUp } from 'lucide-astro';
+---
+
+<span class="scroll-top-marker" data-scroll-top-marker aria-hidden="true"></span>
+<button
+  class="scroll-top-button"
+  type="button"
+  aria-label="返回顶部"
+  title="返回顶部"
+  aria-hidden="true"
+  tabindex="-1"
+  data-scroll-top-button
+>
+  <ArrowUp size={18} stroke-width={2} aria-hidden="true" focusable="false" />
+</button>
+
+<script>
+  const initScrollToTopButton = () => {
+    for (const button of document.querySelectorAll<HTMLButtonElement>('[data-scroll-top-button]')) {
+      if (button.dataset.scrollTopReady === 'true') {
+        continue;
+      }
+
+      button.dataset.scrollTopReady = 'true';
+      const marker = button.previousElementSibling;
+      const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+      const setVisible = (visible: boolean) => {
+        button.dataset.visible = visible ? 'true' : 'false';
+        button.setAttribute('aria-hidden', String(!visible));
+        button.tabIndex = visible ? 0 : -1;
+      };
+
+      const shouldShow = () => window.scrollY > window.innerHeight;
+
+      if (marker) {
+        const observer = new IntersectionObserver(([entry]) => {
+          setVisible(entry.boundingClientRect.top < 0 && !entry.isIntersecting);
+        });
+
+        observer.observe(marker);
+      } else {
+        let frame = 0;
+        const update = () => {
+          frame = 0;
+          setVisible(shouldShow());
+        };
+
+        window.addEventListener(
+          'scroll',
+          () => {
+            if (!frame) {
+              frame = window.requestAnimationFrame(update);
+            }
+          },
+          { passive: true },
+        );
+      }
+
+      window.addEventListener('resize', () => setVisible(shouldShow()));
+      button.addEventListener('click', () => {
+        window.scrollTo({
+          top: 0,
+          behavior: prefersReducedMotion.matches ? 'auto' : 'smooth',
+        });
+      });
+
+      setVisible(shouldShow());
+    }
+  };
+
+  initScrollToTopButton();
+  document.addEventListener('astro:page-load', initScrollToTopButton);
+</script>
+
+<style>
+  .scroll-top-marker {
+    position: absolute;
+    top: 100vh;
+    left: 0;
+    width: 1px;
+    height: 1px;
+    pointer-events: none;
+  }
+
+  .scroll-top-button {
+    position: fixed;
+    right: max(18px, env(safe-area-inset-right));
+    bottom: max(18px, env(safe-area-inset-bottom));
+    z-index: 45;
+    display: inline-grid;
+    place-items: center;
+    width: 42px;
+    height: 42px;
+    padding: 0;
+    border: 1px solid var(--paper-line);
+    border-radius: 8px;
+    background: var(--paper-nav);
+    color: var(--paper-ink-soft);
+    box-shadow: var(--paper-shadow);
+    cursor: pointer;
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(8px) scale(0.98);
+    transition:
+      opacity 180ms ease,
+      transform 180ms ease,
+      border-color 180ms ease,
+      background 180ms ease,
+      color 180ms ease;
+  }
+
+  .scroll-top-button[data-visible='true'] {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0) scale(1);
+  }
+
+  .scroll-top-button:hover,
+  .scroll-top-button:focus-visible {
+    border-color: var(--paper-line-strong);
+    background: var(--paper-control-hover);
+    color: var(--paper-accent);
+  }
+
+  .scroll-top-button:focus-visible {
+    outline: 2px solid color-mix(in srgb, var(--paper-accent), transparent 58%);
+    outline-offset: 3px;
+  }
+
+  @media (max-width: 720px) {
+    .scroll-top-button {
+      right: max(14px, env(safe-area-inset-right));
+      bottom: max(14px, env(safe-area-inset-bottom));
+      width: 40px;
+      height: 40px;
+      border-radius: 7px;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .scroll-top-button {
+      transition: none;
+    }
+  }
+</style>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -2,6 +2,7 @@
 import BaseHead from '../components/BaseHead.astro';
 import BlogTopNav from '../components/blog/BlogTopNav.astro';
 import FullFontWarmup from '../components/FullFontWarmup.astro';
+import ScrollToTopButton from '../components/ScrollToTopButton.astro';
 import { getThemePalette } from '../data/site';
 
 interface Props {
@@ -21,6 +22,7 @@ const palette = await getThemePalette();
   <body>
     <BlogTopNav />
     <slot />
+    <ScrollToTopButton />
     <FullFontWarmup />
   </body>
 </html>

--- a/src/layouts/BlogArticle.astro
+++ b/src/layouts/BlogArticle.astro
@@ -3,6 +3,7 @@ import { type CollectionEntry, getCollection } from 'astro:content';
 import ArticleHeader from '../components/article/ArticleHeader.astro';
 import BlogTopNav from '../components/blog/BlogTopNav.astro';
 import RelatedPosts from '../components/blog/RelatedPosts.astro';
+import ScrollToTopButton from '../components/ScrollToTopButton.astro';
 import TableOfContents from '../components/blog/TableOfContents.astro';
 import BaseHead from '../components/BaseHead.astro';
 import CommentSection from '../components/comments/CommentSection.astro';
@@ -216,6 +217,7 @@ const hasSidebar = shouldRenderSidebar && hasToc;
         )
       }
     </main>
+    <ScrollToTopButton />
   </body>
 </html>
 

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -3,6 +3,7 @@ import type { CollectionEntry } from 'astro:content';
 import BaseHead from '../components/BaseHead.astro';
 import Footer from '../components/Footer.astro';
 import FormattedDate from '../components/FormattedDate.astro';
+import ScrollToTopButton from '../components/ScrollToTopButton.astro';
 import SmartImage from '../components/SmartImage.astro';
 import BlogTopNav from '../components/blog/BlogTopNav.astro';
 import { getThemePalette } from '../data/site';
@@ -103,6 +104,7 @@ const palette = await getThemePalette();
         </div>
       </article>
     </main>
+    <ScrollToTopButton />
     <Footer />
   </body>
 </html>


### PR DESCRIPTION
## Summary

- Add a reusable `ScrollToTopButton` Astro component
- Mount it across site layouts so it works on home, article, archive, and standalone pages
- Show the button only after scrolling past the first viewport
- Smoothly scroll back to the top on click and hide again after returning

## Verification

- `bun run format:check`
- `bun run build`

## Notes

The button uses existing `paper-*` design tokens, subtle opacity/transform motion, and responsive sizing for desktop and mobile.


close #64 