### PR TITLE
Fix zoomable image gallery preview controls

### DIFF
--- a/src/components/mdx/ZoomableImage.astro
+++ b/src/components/mdx/ZoomableImage.astro
@@ -1,5 +1,5 @@
 ---
-import { ZoomIn } from 'lucide-astro';
+import { ChevronLeft, ChevronRight, X, ZoomIn } from 'lucide-astro';
 import type { ImageMetadata } from 'astro';
 import type { HTMLAttributes } from 'astro/types';
 
@@ -20,7 +20,7 @@ const hasImageSource = resolvedSrc !== undefined && resolvedSrc !== null;
 ---
 
 {
-  hasImageSource && (
+  hasImageSource ? (
     <span class="zoomable-image" data-zoomable-image data-preview-label={previewLabel}>
       <img
         {...imageProps}
@@ -30,6 +30,7 @@ const hasImageSource = resolvedSrc !== undefined && resolvedSrc !== null;
         height={resolvedHeight}
         class={imageClass || undefined}
         data-zoomable-image-target
+        draggable="false"
       />
       <span class="zoomable-image__veil" aria-hidden="true">
         <span class="zoomable-image__icon">
@@ -37,6 +38,41 @@ const hasImageSource = resolvedSrc !== undefined && resolvedSrc !== null;
         </span>
       </span>
     </span>
+  ) : (
+    <dialog class="zoomable-image-lightbox" data-zoomable-lightbox aria-label="Image preview">
+      <button
+        class="zoomable-image-lightbox__close"
+        type="button"
+        aria-label="Close image preview"
+        data-zoomable-lightbox-close
+      >
+        <X size={22} strokeWidth={1.8} aria-hidden="true" />
+      </button>
+      <button
+        class="zoomable-image-lightbox__nav zoomable-image-lightbox__nav--prev"
+        type="button"
+        aria-label="Previous image"
+        data-zoomable-lightbox-prev
+        hidden
+      >
+        <ChevronLeft size={24} strokeWidth={1.8} aria-hidden="true" />
+      </button>
+      <img
+        class="zoomable-image-lightbox__image"
+        alt=""
+        draggable="false"
+        data-zoomable-lightbox-image
+      />
+      <button
+        class="zoomable-image-lightbox__nav zoomable-image-lightbox__nav--next"
+        type="button"
+        aria-label="Next image"
+        data-zoomable-lightbox-next
+        hidden
+      >
+        <ChevronRight size={24} strokeWidth={1.8} aria-hidden="true" />
+      </button>
+    </dialog>
   )
 }
 
@@ -62,6 +98,9 @@ const hasImageSource = resolvedSrc !== undefined && resolvedSrc !== null;
     border-radius: 8px;
     background: var(--paper-surface-muted);
     cursor: pointer;
+    user-select: none;
+    -webkit-user-drag: none;
+    -webkit-tap-highlight-color: transparent;
   }
 
   :global(.zoomable-image:focus-visible) {
@@ -73,6 +112,8 @@ const hasImageSource = resolvedSrc !== undefined && resolvedSrc !== null;
     display: block;
     max-width: 100%;
     height: auto;
+    user-select: none;
+    -webkit-user-drag: none;
   }
 
   :global(.zoomable-image__veil) {
@@ -130,11 +171,17 @@ const hasImageSource = resolvedSrc !== undefined && resolvedSrc !== null;
     border-radius: 8px;
     background: var(--paper-surface-muted);
     cursor: pointer;
+    user-select: none;
+    -webkit-user-drag: none;
+    -webkit-tap-highlight-color: transparent;
   }
 
   :global(.article-content figure:has(> img):not(:has(a[href]))) {
     position: relative;
     cursor: pointer;
+    user-select: none;
+    -webkit-user-drag: none;
+    -webkit-tap-highlight-color: transparent;
   }
 
   :global(.article-content > p:has(> img):not(:has(a[href])) > img),
@@ -142,6 +189,8 @@ const hasImageSource = resolvedSrc !== undefined && resolvedSrc !== null;
     display: block;
     max-width: 100%;
     height: auto;
+    user-select: none;
+    -webkit-user-drag: none;
   }
 
   :global(.article-content > p:has(> img):not(:has(a[href]))::before),
@@ -204,15 +253,35 @@ const hasImageSource = resolvedSrc !== undefined && resolvedSrc !== null;
     position: fixed;
     inset: 0;
     z-index: 1000;
-    display: grid;
-    place-items: center;
+    width: 100%;
+    max-width: none;
+    height: 100%;
+    max-height: none;
+    margin: 0;
     padding: 28px;
+    border: 0;
     background: color-mix(in srgb, var(--paper-ink) 72%, transparent);
+    color: var(--paper-ink);
     opacity: 0;
     visibility: hidden;
+    user-select: none;
+    -webkit-tap-highlight-color: transparent;
     transition:
       opacity 180ms ease,
       visibility 180ms ease;
+  }
+
+  :global(.zoomable-image-lightbox:not([open])) {
+    display: none;
+  }
+
+  :global(.zoomable-image-lightbox[open]) {
+    display: grid;
+    place-items: center;
+  }
+
+  :global(.zoomable-image-lightbox::backdrop) {
+    background: transparent;
   }
 
   :global(.zoomable-image-lightbox.is-open) {
@@ -227,6 +296,8 @@ const hasImageSource = resolvedSrc !== undefined && resolvedSrc !== null;
     object-fit: contain;
     border-radius: 8px;
     box-shadow: 0 18px 56px color-mix(in srgb, #000 32%, transparent);
+    user-select: none;
+    -webkit-user-drag: none;
   }
 
   :global(.zoomable-image-lightbox__close) {
@@ -243,6 +314,7 @@ const hasImageSource = resolvedSrc !== undefined && resolvedSrc !== null;
     background: color-mix(in srgb, var(--paper-surface) 90%, transparent);
     color: var(--paper-ink);
     cursor: pointer;
+    user-select: none;
   }
 
   :global(.zoomable-image-lightbox__nav) {
@@ -259,6 +331,7 @@ const hasImageSource = resolvedSrc !== undefined && resolvedSrc !== null;
     color: var(--paper-ink);
     cursor: pointer;
     opacity: 0.92;
+    user-select: none;
     transform: translateY(-50%);
     transition:
       background 160ms ease,

--- a/src/pages/vibe.astro
+++ b/src/pages/vibe.astro
@@ -605,6 +605,7 @@ const vibes = await Promise.all(
                     class:list={['vibe-images', imageLayout.isCollapsible && 'is-collapsible']}
                     style={`--vibe-image-columns: ${imageLayout.columns};`}
                     data-vibe-image-group
+                    data-zoomable-gallery
                     data-vibe-image-count={imageLayout.count}
                     data-vibe-image-columns={imageLayout.columns}
                     aria-label={`${entry.data.title ?? entry.id} images`}

--- a/src/utils/zoomable-images.ts
+++ b/src/utils/zoomable-images.ts
@@ -5,7 +5,7 @@ declare global {
 }
 
 type LightboxElements = {
-  root: HTMLDivElement;
+  root: HTMLDialogElement;
   image: HTMLImageElement;
   closeButton: HTMLButtonElement;
   prevButton: HTMLButtonElement;
@@ -13,9 +13,17 @@ type LightboxElements = {
 };
 
 let lightboxElements: LightboxElements | undefined;
-let previousBodyOverflow = '';
+let previousActiveElement: HTMLElement | undefined;
 let activeGallery: HTMLImageElement[] = [];
 let activeGalleryIndex = -1;
+
+const LIGHTBOX_SELECTOR = '[data-zoomable-lightbox]';
+const LIGHTBOX_IMAGE_SELECTOR = '[data-zoomable-lightbox-image]';
+const LIGHTBOX_CLOSE_SELECTOR = '[data-zoomable-lightbox-close]';
+const LIGHTBOX_PREV_SELECTOR = '[data-zoomable-lightbox-prev]';
+const LIGHTBOX_NEXT_SELECTOR = '[data-zoomable-lightbox-next]';
+const ZOOMABLE_TARGET_SELECTOR = '[data-zoomable-image-target]';
+const ZOOMABLE_GALLERY_SELECTOR = '[data-zoomable-gallery], astro-carousel';
 
 const isPlainMarkdownImage = (target: HTMLImageElement) =>
   Boolean(target.closest('.article-content')) &&
@@ -30,7 +38,7 @@ const getZoomTarget = (target: EventTarget | null): HTMLImageElement | undefined
 
   const wrappedImage = target
     .closest('[data-zoomable-image]')
-    ?.querySelector('[data-zoomable-image-target]');
+    ?.querySelector(ZOOMABLE_TARGET_SELECTOR);
 
   if (wrappedImage instanceof HTMLImageElement && !wrappedImage.closest('a[href]')) {
     return wrappedImage;
@@ -43,15 +51,17 @@ const getZoomTarget = (target: EventTarget | null): HTMLImageElement | undefined
   return undefined;
 };
 
-const getCarouselGallery = (sourceImage: HTMLImageElement) => {
-  const carousel = sourceImage.closest('astro-carousel');
+const getGalleryImages = (sourceImage: HTMLImageElement) => {
+  const galleryRoot = sourceImage.closest(ZOOMABLE_GALLERY_SELECTOR);
 
-  if (!carousel) {
+  if (!galleryRoot) {
     return { images: [sourceImage], index: 0 };
   }
 
   const images = Array.from(
-    carousel.querySelectorAll<HTMLImageElement>('[data-carousel-slide] img'),
+    galleryRoot.querySelectorAll<HTMLImageElement>(
+      `${ZOOMABLE_TARGET_SELECTOR}, [data-carousel-slide] img`,
+    ),
   )
     .filter((image) => !image.closest('a[href]'))
     .filter((image) => image.currentSrc || image.src);
@@ -101,49 +111,39 @@ const movePreview = (offset: number) => {
 };
 
 const closePreview = () => {
-  if (!lightboxElements) {
+  const lightbox = getLightbox();
+
+  if (!lightbox) {
     return;
   }
 
-  lightboxElements.root.classList.remove('is-open');
-  lightboxElements.root.setAttribute('aria-hidden', 'true');
-  document.body.style.overflow = previousBodyOverflow;
-  lightboxElements.image.removeAttribute('src');
-  lightboxElements.image.alt = '';
-  lightboxElements.image.removeAttribute('title');
+  lightbox.root.classList.remove('is-open');
+  lightbox.root.close();
+  lightbox.image.removeAttribute('src');
+  lightbox.image.alt = '';
+  lightbox.image.removeAttribute('title');
   activeGallery = [];
   activeGalleryIndex = -1;
   syncGalleryControls();
+  previousActiveElement?.focus({ preventScroll: true });
+  previousActiveElement = undefined;
 };
 
-const createLightbox = (): LightboxElements => {
-  const root = document.createElement('div');
-  root.className = 'zoomable-image-lightbox';
-  root.setAttribute('aria-hidden', 'true');
-  root.innerHTML = `
-    <button class="zoomable-image-lightbox__close" type="button" aria-label="Close image preview">
-      <svg aria-hidden="true" viewBox="0 0 24 24" width="22" height="22">
-        <path d="M18 6 6 18M6 6l12 12" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8"></path>
-      </svg>
-    </button>
-    <button class="zoomable-image-lightbox__nav zoomable-image-lightbox__nav--prev" type="button" aria-label="Previous image" hidden>
-      <svg aria-hidden="true" viewBox="0 0 24 24" width="24" height="24">
-        <path d="m15 18-6-6 6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8"></path>
-      </svg>
-    </button>
-    <img class="zoomable-image-lightbox__image" alt="" />
-    <button class="zoomable-image-lightbox__nav zoomable-image-lightbox__nav--next" type="button" aria-label="Next image" hidden>
-      <svg aria-hidden="true" viewBox="0 0 24 24" width="24" height="24">
-        <path d="m9 18 6-6-6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8"></path>
-      </svg>
-    </button>
-  `;
-  document.body.append(root);
+const getLightbox = (): LightboxElements | undefined => {
+  if (lightboxElements?.root.isConnected) {
+    return lightboxElements;
+  }
 
-  const image = root.querySelector('.zoomable-image-lightbox__image');
-  const closeButton = root.querySelector('.zoomable-image-lightbox__close');
-  const prevButton = root.querySelector('.zoomable-image-lightbox__nav--prev');
-  const nextButton = root.querySelector('.zoomable-image-lightbox__nav--next');
+  const root = document.querySelector(LIGHTBOX_SELECTOR);
+
+  if (!(root instanceof HTMLDialogElement)) {
+    return undefined;
+  }
+
+  const image = root.querySelector(LIGHTBOX_IMAGE_SELECTOR);
+  const closeButton = root.querySelector(LIGHTBOX_CLOSE_SELECTOR);
+  const prevButton = root.querySelector(LIGHTBOX_PREV_SELECTOR);
+  const nextButton = root.querySelector(LIGHTBOX_NEXT_SELECTOR);
 
   if (
     !(image instanceof HTMLImageElement) ||
@@ -151,41 +151,65 @@ const createLightbox = (): LightboxElements => {
     !(prevButton instanceof HTMLButtonElement) ||
     !(nextButton instanceof HTMLButtonElement)
   ) {
-    throw new Error('Failed to initialize zoomable image lightbox.');
+    return undefined;
   }
 
-  root.addEventListener('click', (event) => {
-    if (event.target === root) {
-      closePreview();
-    }
-  });
-
-  closeButton.addEventListener('click', closePreview);
-  prevButton.addEventListener('click', () => movePreview(-1));
-  nextButton.addEventListener('click', () => movePreview(1));
-
-  return { root, image, closeButton, prevButton, nextButton };
-};
-
-const getLightbox = (): LightboxElements => {
-  lightboxElements ??= createLightbox();
+  lightboxElements = { root, image, closeButton, prevButton, nextButton };
   return lightboxElements;
 };
 
 const openPreview = (sourceImage: HTMLImageElement) => {
-  const { root, closeButton } = getLightbox();
-  const gallery = getCarouselGallery(sourceImage);
+  const lightbox = getLightbox();
 
-  previousBodyOverflow = document.body.style.overflow;
+  if (!lightbox) {
+    return;
+  }
+
+  const { root, closeButton } = lightbox;
+  const gallery = getGalleryImages(sourceImage);
+
+  previousActiveElement =
+    document.activeElement instanceof HTMLElement ? document.activeElement : undefined;
   activeGallery = gallery.images;
   activeGalleryIndex = gallery.index;
   setPreviewImage(sourceImage);
   syncGalleryControls();
 
-  document.body.style.overflow = 'hidden';
   root.classList.add('is-open');
-  root.setAttribute('aria-hidden', 'false');
+  if (!root.open) {
+    root.showModal();
+  }
   closeButton.focus({ preventScroll: true });
+};
+
+const handleLightboxClick = (target: EventTarget | null) => {
+  if (!(target instanceof Element)) {
+    return false;
+  }
+
+  if (target.closest(LIGHTBOX_CLOSE_SELECTOR)) {
+    closePreview();
+    return true;
+  }
+
+  if (target.closest(LIGHTBOX_PREV_SELECTOR)) {
+    movePreview(-1);
+    return true;
+  }
+
+  if (target.closest(LIGHTBOX_NEXT_SELECTOR)) {
+    movePreview(1);
+    return true;
+  }
+
+  const lightbox = getLightbox();
+
+  if (lightbox && target === lightbox.root) {
+    closePreview();
+    return true;
+  }
+
+  return false;
 };
 
 export const initZoomableImages = () => {
@@ -196,6 +220,10 @@ export const initZoomableImages = () => {
   window.__navfolioZoomableImagesReady = true;
 
   document.addEventListener('click', (event) => {
+    if (handleLightboxClick(event.target)) {
+      return;
+    }
+
     const image = getZoomTarget(event.target);
 
     if (image) {
@@ -203,13 +231,33 @@ export const initZoomableImages = () => {
     }
   });
 
+  document.addEventListener('dragstart', (event) => {
+    const lightbox = getLightbox();
+
+    if (
+      lightbox?.root.open &&
+      event.target instanceof Node &&
+      lightbox.root.contains(event.target)
+    ) {
+      event.preventDefault();
+      return;
+    }
+
+    if (getZoomTarget(event.target)) {
+      event.preventDefault();
+    }
+  });
+
   document.addEventListener('keydown', (event) => {
-    if (event.key === 'Escape' && lightboxElements?.root.classList.contains('is-open')) {
+    const lightbox = getLightbox();
+    const isOpen = lightbox?.root.open;
+
+    if (event.key === 'Escape' && isOpen) {
       closePreview();
       return;
     }
 
-    if (lightboxElements?.root.classList.contains('is-open')) {
+    if (isOpen) {
       if (event.key === 'ArrowLeft') {
         event.preventDefault();
         movePreview(-1);


### PR DESCRIPTION
## Summary

- Mark vibe image groups as zoomable galleries so fullscreen preview can switch between images in the same vibe entry
- Move the zoom lightbox structure into the Astro component instead of creating the whole DOM tree at runtime
- Keep zoom preview interactions cleaner by disabling image drag/selection states that could show the browser default blue highlight

## Verification

- `bunx tsc --ignoreConfig --noEmit --strict --lib dom,es2022 src/utils/zoomable-images.ts`
- `bun run format:check`
- `bun run build`

## Notes

The commit hook also ran format/build successfully during commit.

cloes #73 