### PR TITLE
Fix zoomable image review feedback

### DIFF
--- a/src/components/mdx/ZoomableImage.astro
+++ b/src/components/mdx/ZoomableImage.astro
@@ -20,7 +20,7 @@ const hasImageSource = resolvedSrc !== undefined && resolvedSrc !== null;
 ---
 
 {
-  hasImageSource && (
+  hasImageSource ? (
     <span class="zoomable-image" data-zoomable-image data-preview-label={previewLabel}>
       <img
         {...imageProps}
@@ -38,11 +38,11 @@ const hasImageSource = resolvedSrc !== undefined && resolvedSrc !== null;
         </span>
       </span>
     </span>
-  )
+  ) : null
 }
 
 {
-  !hasImageSource && (
+  !hasImageSource ? (
     <dialog class="zoomable-image-lightbox" data-zoomable-lightbox aria-label="Image preview">
       <button
         class="zoomable-image-lightbox__close"
@@ -77,7 +77,7 @@ const hasImageSource = resolvedSrc !== undefined && resolvedSrc !== null;
         <ChevronRight size={24} strokeWidth={1.8} aria-hidden="true" />
       </button>
     </dialog>
-  )
+  ) : null
 }
 
 <script>

--- a/src/components/mdx/ZoomableImage.astro
+++ b/src/components/mdx/ZoomableImage.astro
@@ -20,7 +20,7 @@ const hasImageSource = resolvedSrc !== undefined && resolvedSrc !== null;
 ---
 
 {
-  hasImageSource ? (
+  hasImageSource && (
     <span class="zoomable-image" data-zoomable-image data-preview-label={previewLabel}>
       <img
         {...imageProps}
@@ -38,7 +38,11 @@ const hasImageSource = resolvedSrc !== undefined && resolvedSrc !== null;
         </span>
       </span>
     </span>
-  ) : (
+  )
+}
+
+{
+  !hasImageSource && (
     <dialog class="zoomable-image-lightbox" data-zoomable-lightbox aria-label="Image preview">
       <button
         class="zoomable-image-lightbox__close"
@@ -268,7 +272,16 @@ const hasImageSource = resolvedSrc !== undefined && resolvedSrc !== null;
     -webkit-tap-highlight-color: transparent;
     transition:
       opacity 180ms ease,
-      visibility 180ms ease;
+      visibility 180ms ease,
+      display 180ms ease allow-discrete,
+      overlay 180ms ease allow-discrete;
+  }
+
+  @starting-style {
+    :global(.zoomable-image-lightbox[open]) {
+      opacity: 0;
+      visibility: hidden;
+    }
   }
 
   :global(.zoomable-image-lightbox:not([open])) {

--- a/src/layouts/BlogArticle.astro
+++ b/src/layouts/BlogArticle.astro
@@ -7,6 +7,7 @@ import ScrollToTopButton from '../components/ScrollToTopButton.astro';
 import TableOfContents from '../components/blog/TableOfContents.astro';
 import BaseHead from '../components/BaseHead.astro';
 import CommentSection from '../components/comments/CommentSection.astro';
+import ZoomableImage from '../components/mdx/ZoomableImage.astro';
 import { getThemePalette, getSiteConfig } from '../data/site';
 import { resolveCommentsConfig } from '../utils/comments';
 import { sortByDateDesc } from '../utils/content-dates';
@@ -218,6 +219,7 @@ const hasSidebar = shouldRenderSidebar && hasToc;
       }
     </main>
     <ScrollToTopButton />
+    <ZoomableImage />
   </body>
 </html>
 

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -18,5 +18,4 @@ const { Content, headings } = await render(post);
 
 <BlogArticle post={post} headings={headings}>
   <Content components={{ img: ZoomableImage }} />
-  <ZoomableImage />
 </BlogArticle>

--- a/src/utils/zoomable-images.ts
+++ b/src/utils/zoomable-images.ts
@@ -151,10 +151,9 @@ const closePreview = () => {
 const cleanupPreview = () => {
   const lightbox = lightboxElements;
 
-  lightbox?.root.classList.remove('is-open');
-  lightbox?.image.removeAttribute('src');
-
-  if (lightbox?.image) {
+  if (lightbox) {
+    lightbox.root.classList.remove('is-open');
+    lightbox.image.removeAttribute('src');
     lightbox.image.alt = '';
     lightbox.image.removeAttribute('title');
   }

--- a/src/utils/zoomable-images.ts
+++ b/src/utils/zoomable-images.ts
@@ -16,7 +16,7 @@ let lightboxElements: LightboxElements | undefined;
 let previousActiveElement: HTMLElement | undefined;
 let activeGallery: HTMLImageElement[] = [];
 let activeGalleryIndex = -1;
-let shouldRestoreFocusOnClose = false;
+const boundLightboxRoots = new WeakSet<HTMLDialogElement>();
 
 const LIGHTBOX_SELECTOR = '[data-zoomable-lightbox]';
 const LIGHTBOX_IMAGE_SELECTOR = '[data-zoomable-lightbox-image]';
@@ -137,7 +137,6 @@ const closePreview = () => {
     return;
   }
 
-  shouldRestoreFocusOnClose = true;
   lightbox.root.classList.remove('is-open');
 
   if (lightbox.root.open) {
@@ -162,12 +161,8 @@ const cleanupPreview = () => {
   activeGalleryIndex = -1;
   syncGalleryControls();
 
-  if (shouldRestoreFocusOnClose) {
-    previousActiveElement?.focus({ preventScroll: true });
-  }
-
+  previousActiveElement?.focus({ preventScroll: true });
   previousActiveElement = undefined;
-  shouldRestoreFocusOnClose = false;
 };
 
 const createLightboxRoot = () => {
@@ -183,14 +178,11 @@ const createLightboxRoot = () => {
 };
 
 const bindLightboxRoot = (root: HTMLDialogElement) => {
-  if (root.dataset.zoomableLightboxBound === 'true') {
+  if (boundLightboxRoots.has(root)) {
     return;
   }
 
-  root.dataset.zoomableLightboxBound = 'true';
-  root.addEventListener('cancel', () => {
-    shouldRestoreFocusOnClose = true;
-  });
+  boundLightboxRoots.add(root);
   root.addEventListener('close', cleanupPreview);
 };
 
@@ -238,7 +230,6 @@ const openPreview = (sourceImage: HTMLImageElement) => {
 
   previousActiveElement =
     document.activeElement instanceof HTMLElement ? document.activeElement : undefined;
-  shouldRestoreFocusOnClose = true;
   activeGallery = gallery.images;
   activeGalleryIndex = gallery.index;
   setPreviewImage(sourceImage);
@@ -320,12 +311,6 @@ export const initZoomableImages = () => {
   document.addEventListener('keydown', (event) => {
     const lightbox = getLightbox();
     const isOpen = lightbox?.root.open;
-
-    if (event.key === 'Escape' && isOpen) {
-      event.preventDefault();
-      closePreview();
-      return;
-    }
 
     if (isOpen) {
       if (event.key === 'ArrowLeft') {

--- a/src/utils/zoomable-images.ts
+++ b/src/utils/zoomable-images.ts
@@ -16,6 +16,7 @@ let lightboxElements: LightboxElements | undefined;
 let previousActiveElement: HTMLElement | undefined;
 let activeGallery: HTMLImageElement[] = [];
 let activeGalleryIndex = -1;
+let shouldRestoreFocusOnClose = false;
 
 const LIGHTBOX_SELECTOR = '[data-zoomable-lightbox]';
 const LIGHTBOX_IMAGE_SELECTOR = '[data-zoomable-lightbox-image]';
@@ -24,6 +25,25 @@ const LIGHTBOX_PREV_SELECTOR = '[data-zoomable-lightbox-prev]';
 const LIGHTBOX_NEXT_SELECTOR = '[data-zoomable-lightbox-next]';
 const ZOOMABLE_TARGET_SELECTOR = '[data-zoomable-image-target]';
 const ZOOMABLE_GALLERY_SELECTOR = '[data-zoomable-gallery], astro-carousel';
+
+const LIGHTBOX_MARKUP = `
+  <button class="zoomable-image-lightbox__close" type="button" aria-label="Close image preview" data-zoomable-lightbox-close>
+    <svg aria-hidden="true" viewBox="0 0 24 24" width="22" height="22">
+      <path d="M18 6 6 18M6 6l12 12" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8"></path>
+    </svg>
+  </button>
+  <button class="zoomable-image-lightbox__nav zoomable-image-lightbox__nav--prev" type="button" aria-label="Previous image" data-zoomable-lightbox-prev hidden>
+    <svg aria-hidden="true" viewBox="0 0 24 24" width="24" height="24">
+      <path d="m15 18-6-6 6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8"></path>
+    </svg>
+  </button>
+  <img class="zoomable-image-lightbox__image" alt="" draggable="false" data-zoomable-lightbox-image />
+  <button class="zoomable-image-lightbox__nav zoomable-image-lightbox__nav--next" type="button" aria-label="Next image" data-zoomable-lightbox-next hidden>
+    <svg aria-hidden="true" viewBox="0 0 24 24" width="24" height="24">
+      <path d="m9 18 6-6-6-6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8"></path>
+    </svg>
+  </button>
+`;
 
 const isPlainMarkdownImage = (target: HTMLImageElement) =>
   Boolean(target.closest('.article-content')) &&
@@ -117,24 +137,72 @@ const closePreview = () => {
     return;
   }
 
+  shouldRestoreFocusOnClose = true;
   lightbox.root.classList.remove('is-open');
-  lightbox.root.close();
-  lightbox.image.removeAttribute('src');
-  lightbox.image.alt = '';
-  lightbox.image.removeAttribute('title');
+
+  if (lightbox.root.open) {
+    lightbox.root.close();
+    return;
+  }
+
+  cleanupPreview();
+};
+
+const cleanupPreview = () => {
+  const lightbox = lightboxElements;
+
+  lightbox?.root.classList.remove('is-open');
+  lightbox?.image.removeAttribute('src');
+
+  if (lightbox?.image) {
+    lightbox.image.alt = '';
+    lightbox.image.removeAttribute('title');
+  }
+
   activeGallery = [];
   activeGalleryIndex = -1;
   syncGalleryControls();
-  previousActiveElement?.focus({ preventScroll: true });
+
+  if (shouldRestoreFocusOnClose) {
+    previousActiveElement?.focus({ preventScroll: true });
+  }
+
   previousActiveElement = undefined;
+  shouldRestoreFocusOnClose = false;
 };
 
-const getLightbox = (): LightboxElements | undefined => {
+const createLightboxRoot = () => {
+  const root = document.createElement('dialog');
+
+  root.className = 'zoomable-image-lightbox';
+  root.setAttribute('aria-label', 'Image preview');
+  root.setAttribute('data-zoomable-lightbox', '');
+  root.innerHTML = LIGHTBOX_MARKUP;
+  document.body.append(root);
+
+  return root;
+};
+
+const bindLightboxRoot = (root: HTMLDialogElement) => {
+  if (root.dataset.zoomableLightboxBound === 'true') {
+    return;
+  }
+
+  root.dataset.zoomableLightboxBound = 'true';
+  root.addEventListener('cancel', () => {
+    shouldRestoreFocusOnClose = true;
+  });
+  root.addEventListener('close', cleanupPreview);
+};
+
+const getLightbox = (createIfMissing = false): LightboxElements | undefined => {
   if (lightboxElements?.root.isConnected) {
     return lightboxElements;
   }
 
-  const root = document.querySelector(LIGHTBOX_SELECTOR);
+  const root =
+    document.querySelector(LIGHTBOX_SELECTOR) ??
+    (createIfMissing ? createLightboxRoot() : undefined);
 
   if (!(root instanceof HTMLDialogElement)) {
     return undefined;
@@ -155,11 +223,12 @@ const getLightbox = (): LightboxElements | undefined => {
   }
 
   lightboxElements = { root, image, closeButton, prevButton, nextButton };
+  bindLightboxRoot(root);
   return lightboxElements;
 };
 
 const openPreview = (sourceImage: HTMLImageElement) => {
-  const lightbox = getLightbox();
+  const lightbox = getLightbox(true);
 
   if (!lightbox) {
     return;
@@ -170,6 +239,7 @@ const openPreview = (sourceImage: HTMLImageElement) => {
 
   previousActiveElement =
     document.activeElement instanceof HTMLElement ? document.activeElement : undefined;
+  shouldRestoreFocusOnClose = true;
   activeGallery = gallery.images;
   activeGalleryIndex = gallery.index;
   setPreviewImage(sourceImage);
@@ -253,6 +323,7 @@ export const initZoomableImages = () => {
     const isOpen = lightbox?.root.open;
 
     if (event.key === 'Escape' && isOpen) {
+      event.preventDefault();
       closePreview();
       return;
     }


### PR DESCRIPTION
## Summary

- Ensure zoom preview still works when pages only render `ZoomableImage` instances with `src`
- Move the zoom lightbox host into `BlogArticle` so article-style pages have a shared preview root
- Add a fallback lightbox root creation path for standalone zoomable image usage
- Clean up preview state through the native dialog `close` event so Escape/native close paths stay in sync
- Add discrete dialog transitions with `allow-discrete` and `@starting-style` to preserve the lightbox fade

## Addresses

- PR #75 review: missing dialog host when all `ZoomableImage` components have `src`
- PR #75 review: native dialog close can bypass cleanup
- PR #75 review: dialog display switch can skip opacity transition

## Verification

- `bunx tsc --ignoreConfig --noEmit --strict --lib dom,es2022 src/utils/zoomable-images.ts`
- `bun run format:check`
- `bun run build`

## Notes

Commit hook also ran format/build successfully during commit.

close #73 