### PR TITLE
feat: add configurable font system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,4 @@ AGENTS.md
 
 # generated font files
 scripts/fonts/ui-chars.txt
-public/fonts/lxgw-ui-subset.woff2
+public/fonts/*-subset.woff2

--- a/scripts/fonts/subset-ui-font.ts
+++ b/scripts/fonts/subset-ui-font.ts
@@ -1,11 +1,21 @@
 import { spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { extname, join } from 'node:path';
+import { dirname, extname, join } from 'node:path';
+import { parse } from 'smol-toml';
+
+type FontConfig = {
+  en: string;
+  zh: string;
+  file: string;
+};
 
 const projectRoot = process.cwd();
 const uiCharsPath = join(projectRoot, 'scripts/fonts/ui-chars.txt');
-const outputFontPath = join(projectRoot, 'public/fonts/lxgw-ui-subset.woff2');
-const sourceFontPath = join(projectRoot, 'public/fonts/LXGWWenKai-Regular.ttf');
+const fontConfig = readFontConfig();
+const subsetFontUrl = getSubsetFontUrl(fontConfig.file);
+const outputFontPath = resolveProjectPath(subsetFontUrl);
+const sourceFontPath = resolveProjectPath(fontConfig.file);
+const subsetFontName = `${fontConfig.zh} UI Subset`;
 const contentSource = process.env.NAVFOLIO_CONTENT_SOURCE === 'docs' ? 'docs' : 'content';
 const contentRoot = contentSource === 'docs' ? 'src/docs' : 'src/content';
 
@@ -27,6 +37,57 @@ const frontmatterExtensions = new Set(['.md', '.mdx']);
 const frontmatterKeys = new Set(['title', 'description', 'tags', 'categories', 'series']);
 const cjkPattern =
   /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}\u3000-\u303f\uff00-\uffef]/u;
+
+function readFontConfig(): FontConfig {
+  const defaults: FontConfig = {
+    en: 'Maple Mono',
+    zh: 'ChillRoundM',
+    file: '/fonts/ChillRoundM.ttf',
+  };
+  const siteConfigPath = join(projectRoot, 'src/config/site.toml');
+
+  if (!existsSync(siteConfigPath)) return defaults;
+
+  const parsed = parse(readFileSync(siteConfigPath, 'utf8')) as {
+    config?: {
+      fonts?: Partial<Record<keyof FontConfig, unknown>>;
+    };
+  };
+  const fonts = parsed.config?.fonts ?? {};
+
+  return {
+    en: normalizeConfigString(fonts.en, defaults.en),
+    zh: normalizeConfigString(fonts.zh, defaults.zh),
+    file: normalizeConfigString(fonts.file, defaults.file),
+  };
+}
+
+function getSubsetFontUrl(fontUrl: string) {
+  const queryIndex = fontUrl.search(/[?#]/);
+  const suffix = queryIndex === -1 ? '' : fontUrl.slice(queryIndex);
+  const path = queryIndex === -1 ? fontUrl : fontUrl.slice(0, queryIndex);
+  const extensionIndex = path.lastIndexOf('.');
+  const basePath = extensionIndex === -1 ? path : path.slice(0, extensionIndex);
+
+  return `${basePath}-ui-subset.woff2${suffix}`;
+}
+
+function normalizeConfigString(value: unknown, fallback: string) {
+  return typeof value === 'string' && value.trim() ? value.trim() : fallback;
+}
+
+function resolveProjectPath(value: string) {
+  if (/^https?:\/\//i.test(value)) {
+    throw new Error(
+      `Font subsetting needs a local font file, but config.fonts.file received a remote URL: ${value}`,
+    );
+  }
+
+  const normalized = value.replace(/\\/g, '/').replace(/^\/+/, '');
+  const relativePath = normalized.startsWith('public/') ? normalized : `public/${normalized}`;
+
+  return join(projectRoot, relativePath);
+}
 
 function walkFiles(dir: string, extensions: Set<string>) {
   if (!existsSync(dir)) return [];
@@ -115,6 +176,45 @@ function runSubset() {
   );
 }
 
+function syncSubsetFontName() {
+  const script = `
+from fontTools.ttLib import TTFont
+import sys
+
+path = sys.argv[1]
+family = sys.argv[2]
+font = TTFont(path)
+name_table = font['name']
+
+for record in name_table.names:
+    if record.nameID == 1:
+        record.string = family.encode(record.getEncoding(), errors='replace')
+    elif record.nameID == 2:
+        record.string = 'Regular'.encode(record.getEncoding(), errors='replace')
+    elif record.nameID == 4:
+        record.string = f'{family} Regular'.encode(record.getEncoding(), errors='replace')
+    elif record.nameID == 6:
+        record.string = ''.join(part for part in f'{family}-Regular' if part.isalnum() or part == '-').encode(record.getEncoding(), errors='replace')
+
+font.save(path)
+`;
+  let result = spawnSync('python3', ['-c', script, outputFontPath, subsetFontName], {
+    stdio: 'inherit',
+  });
+
+  if (result.error || result.status !== 0) {
+    result = spawnSync('python', ['-c', script, outputFontPath, subsetFontName], {
+      stdio: 'inherit',
+    });
+  }
+
+  if (result.error || result.status !== 0) {
+    throw new Error(
+      `Generated subset font, but failed to sync its internal name to ${subsetFontName}. Ensure Python 3 and fonttools are installed. Error: ${result.error?.message ?? `status ${result.status}`}`,
+    );
+  }
+}
+
 const chars = new Set<string>();
 
 for (const dir of sourceDirs) {
@@ -145,16 +245,17 @@ const uiChars = [...chars].sort((a, b) => a.codePointAt(0)! - b.codePointAt(0)!)
 if (!uiChars) throw new Error('No CJK UI characters were found for font subsetting.');
 
 mkdirSync(join(projectRoot, 'scripts/fonts'), { recursive: true });
-mkdirSync(join(projectRoot, 'public/fonts'), { recursive: true });
+mkdirSync(dirname(outputFontPath), { recursive: true });
 writeFileSync(uiCharsPath, `${uiChars}\n`, 'utf8');
 
 if (!existsSync(sourceFontPath)) {
   throw new Error(
-    'LXGW WenKai source font not found. Place the full font at public/fonts/LXGWWenKai-Regular.ttf.',
+    `${fontConfig.zh} source font not found. Place the full font at ${sourceFontPath}, or update config.fonts.file in src/config/site.toml.`,
   );
 }
 
 runSubset();
+syncSubsetFontName();
 
 console.log(`Generated ${uiCharsPath} with ${uiChars.length} CJK UI characters.`);
-console.log(`Generated ${outputFontPath} from ${sourceFontPath}.`);
+console.log(`Generated ${subsetFontName} at ${outputFontPath} from ${sourceFontPath}.`);

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -18,12 +18,78 @@ const assetPath = (path: string) => `${import.meta.env.BASE_URL}${path}`;
 
 const { title, description, image = FallbackImage } = Astro.props;
 const imageUrl = typeof image === 'string' ? image : image.src;
-const { site } = await getSiteConfig();
+const { site, fonts } = await getSiteConfig();
+const fontVariablesCss = createFontCss(fonts);
+
+function normalizeFontFamilyName(fontFamily: string) {
+  return fontFamily
+    .replace(/[\u0000-\u001f\u007f]/g, ' ')
+    .trim()
+    .replace(/^['"]|['"]$/g, '');
+}
+
+function toCssFontFamily(fontFamily: string) {
+  const normalized = normalizeFontFamilyName(fontFamily);
+
+  return `"${normalized.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+function toCssString(value: string) {
+  const normalized = value.replace(/[\u0000-\u001f\u007f]/g, '').trim();
+
+  return `"${normalized.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+function resolveAssetUrl(url: string) {
+  if (/^(?:https?:)?\/\//i.test(url) || url.startsWith('data:')) return url;
+
+  const baseUrl = import.meta.env.BASE_URL.replace(/\/$/, '');
+  const assetUrl = url.startsWith('/') ? url : `/${url}`;
+
+  return `${baseUrl}${assetUrl}`;
+}
+
+function getFontFormat(url: string) {
+  const extension = url.split('?')[0]?.split('#')[0]?.split('.').pop()?.toLowerCase();
+
+  if (extension === 'woff2') return 'woff2';
+  if (extension === 'woff') return 'woff';
+  if (extension === 'otf') return 'opentype';
+
+  return 'truetype';
+}
+
+function getSubsetFontUrl(fontUrl: string) {
+  const queryIndex = fontUrl.search(/[?#]/);
+  const suffix = queryIndex === -1 ? '' : fontUrl.slice(queryIndex);
+  const path = queryIndex === -1 ? fontUrl : fontUrl.slice(0, queryIndex);
+  const extensionIndex = path.lastIndexOf('.');
+  const basePath = extensionIndex === -1 ? path : path.slice(0, extensionIndex);
+
+  return `${basePath}-ui-subset.woff2${suffix}`;
+}
+
+function createFontCss(fonts: { en: string; zh: string; file: string }) {
+  const zhFontName = normalizeFontFamilyName(fonts.zh);
+  const zhFamily = toCssFontFamily(zhFontName);
+  const zhSubsetFamily = toCssFontFamily(`${zhFontName} UI Subset`);
+  const enFamily = toCssFontFamily(fonts.en);
+  const fontFile = toCssString(resolveAssetUrl(fonts.file));
+  const subsetUrl = getSubsetFontUrl(fonts.file);
+  const subsetFile = toCssString(resolveAssetUrl(subsetUrl));
+
+  return `
+@font-face{font-family:${zhSubsetFamily};src:url(${subsetFile}) format("${getFontFormat(subsetUrl)}");font-style:normal;font-weight:400;font-display:swap;}
+@font-face{font-family:${zhFamily};src:url(${fontFile}) format("${getFontFormat(fonts.file)}");font-style:normal;font-weight:400;font-display:swap;}
+html:root{--font-config-en:${enFamily};--font-config-zh:${zhFamily};--font-config-zh-subset:${zhSubsetFamily};}
+`;
+}
 ---
 
 <!-- Global Metadata -->
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
+<style is:inline set:html={fontVariablesCss}></style>
 <ClientRouter />
 <script is:inline>
   (() => {

--- a/src/components/FullFontWarmup.astro
+++ b/src/components/FullFontWarmup.astro
@@ -1,27 +1,40 @@
-<script>
-  const FULL_FONT_URL = '/fonts/LXGWWenKai-Regular.ttf';
-  const FULL_FONT_TYPE = 'font/ttf';
+---
+import { getSiteConfig } from '../data/site';
+
+const { fonts } = await getSiteConfig();
+const fullFontType = getFontMimeType(fonts.file);
+const resolvedFullFontUrl = resolveAssetUrl(fonts.file);
+
+function resolveAssetUrl(url: string) {
+  if (/^(?:https?:)?\/\//i.test(url) || url.startsWith('data:')) return url;
+
+  const baseUrl = import.meta.env.BASE_URL.replace(/\/$/, '');
+  const assetUrl = url.startsWith('/') ? url : `/${url}`;
+
+  return `${baseUrl}${assetUrl}`;
+}
+
+function getFontMimeType(url: string) {
+  const extension = url.split('?')[0]?.split('#')[0]?.split('.').pop()?.toLowerCase();
+
+  if (extension === 'woff2') return 'font/woff2';
+  if (extension === 'woff') return 'font/woff';
+  if (extension === 'otf') return 'font/otf';
+
+  return 'font/ttf';
+}
+---
+
+<script define:vars={{ fullFontUrl: resolvedFullFontUrl, fullFontType }}>
+  const FULL_FONT_URL = fullFontUrl;
+  const FULL_FONT_TYPE = fullFontType;
   const WARMUP_ATTR = 'data-navfolio-full-font-warmup';
 
-  interface ConnectionLike {
-    saveData?: boolean;
-    effectiveType?: string;
-  }
-
-  interface NavigatorWithConnection extends Navigator {
-    connection?: ConnectionLike;
-    mozConnection?: ConnectionLike;
-    webkitConnection?: ConnectionLike;
-  }
-
+  /**
+   * @returns {{ saveData?: boolean, effectiveType?: string } | undefined}
+   */
   function getConnection() {
-    const connectionNavigator = navigator as NavigatorWithConnection;
-
-    return (
-      connectionNavigator.connection ||
-      connectionNavigator.mozConnection ||
-      connectionNavigator.webkitConnection
-    );
+    return navigator.connection || navigator.mozConnection || navigator.webkitConnection;
   }
 
   function shouldSkipWarmup() {
@@ -60,7 +73,10 @@
     document.head.appendChild(link);
   }
 
-  function requestIdle(callback: () => void) {
+  /**
+   * @param {() => void} callback
+   */
+  function requestIdle(callback) {
     if ('requestIdleCallback' in window) {
       window.requestIdleCallback(callback, { timeout: 3000 });
       return;
@@ -72,7 +88,8 @@
   async function waitForCurrentPageFonts() {
     if (!document.fonts?.ready) return;
 
-    let timeoutId: ReturnType<typeof window.setTimeout> | undefined;
+    /** @type {ReturnType<typeof window.setTimeout> | undefined} */
+    let timeoutId;
     const timeoutPromise = new Promise((resolve) => {
       timeoutId = window.setTimeout(resolve, 2000);
     });

--- a/src/config/site.toml
+++ b/src/config/site.toml
@@ -14,6 +14,15 @@ showTrail = true
 # green-soft, green-vivid, rose-soft, pink-soft, purple-soft, blue-soft, orange-soft, brown-soft
 palette = "green-soft"
 
+[config.fonts]
+# 英文与代码感 UI 字体
+en = "Maple Mono"
+# 模板内可直接选择：ChillRoundM、LXGW WenKai
+# 中文阅读字体
+zh = "ChillRoundM"
+# 中文完整字体文件
+file = "/fonts/ChillRoundM.ttf"
+
 [config.code]
 lightTheme = "catppuccin-latte"
 darkTheme = "catppuccin-macchiato"

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -81,6 +81,18 @@ const defaultMathConfig = {
   render: z.infer<typeof mathRendererSchema>;
 };
 
+const defaultFontConfig = {
+  en: 'Maple Mono',
+  zh: 'ChillRoundM',
+  file: '/fonts/ChillRoundM.ttf',
+};
+
+const nonEmptyStringSchema = (fallback: string) =>
+  z.preprocess(
+    (value) => (typeof value === 'string' && value.trim() === '' ? undefined : value),
+    z.string().trim().min(1).optional().default(fallback),
+  );
+
 const defaultGiscusConfig = {
   repo: '',
   repo_id: '',
@@ -167,6 +179,14 @@ const siteConfig = defineCollection({
       .default({
         palette: 'green-soft',
       }),
+    fonts: z
+      .object({
+        en: nonEmptyStringSchema(defaultFontConfig.en),
+        zh: nonEmptyStringSchema(defaultFontConfig.zh),
+        file: nonEmptyStringSchema(defaultFontConfig.file),
+      })
+      .optional()
+      .default(defaultFontConfig),
     code: z
       .object({
         lightTheme: z.string().optional().default(defaultCodeConfig.lightTheme),

--- a/src/styles/fonts.css
+++ b/src/styles/fonts.css
@@ -1,0 +1,4 @@
+@import '@fontsource/maple-mono/400.css';
+@import '@fontsource/maple-mono/500.css';
+@import '@fontsource/maple-mono/600.css';
+@import '@fontsource/maple-mono/700.css';

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,26 +1,6 @@
-@import '@fontsource/maple-mono/400.css';
-@import '@fontsource/maple-mono/500.css';
-@import '@fontsource/maple-mono/600.css';
-@import '@fontsource/maple-mono/700.css';
+@import './fonts.css';
 @import 'katex/dist/katex.min.css';
-
 @import './palettes.css';
-
-@font-face {
-  font-family: 'LXGW UI Subset';
-  src: url('/fonts/lxgw-ui-subset.woff2') format('woff2');
-  font-style: normal;
-  font-weight: 400;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: 'LXGW WenKai Full';
-  src: url('/fonts/LXGWWenKai-Regular.ttf') format('truetype');
-  font-style: normal;
-  font-weight: 400;
-  font-display: swap;
-}
 
 /*
   The CSS in this style tag is based off of Bear Blog's default CSS.
@@ -61,17 +41,23 @@
   --layout-page-bottom: 72px;
   --page-header-spacing: 54px;
   --page-header-spacing-mobile: 28px;
-  --font-cjk-system: 'Maple Mono', 'PingFang SC', 'Microsoft YaHei', system-ui, sans-serif;
-  --font-ui-cjk: 'LXGW UI Subset', var(--font-cjk-system);
+  --font-config-en: 'Maple Mono';
+  --font-config-zh: 'ChillRoundM';
+  --font-config-zh-subset: 'ChillRoundM UI Subset';
+  --font-cjk-system: var(--font-config-en), 'PingFang SC', 'Microsoft YaHei', system-ui, sans-serif;
+  --font-ui-cjk: var(--font-config-zh-subset), var(--font-config-zh), var(--font-cjk-system);
   --font-serif-cn: var(--font-ui-cjk);
   --font-mono:
-    'Maple Mono', 'LXGW UI Subset', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    var(--font-config-en), var(--font-config-zh-subset), ui-monospace, SFMono-Regular, Menlo,
+    Monaco, Consolas, monospace;
   --font-body: var(--font-mono);
   --font-display: var(--font-mono);
   --font-note: var(--font-mono);
-  --font-article: 'Maple Mono', 'LXGW WenKai Full', var(--font-cjk-system);
-  --font-heading: 'Maple Mono', 'LXGW WenKai Full', var(--font-cjk-system);
-  --font-page-heading: 'Maple Mono', 'LXGW UI Subset', var(--font-cjk-system);
+  --font-article: var(--font-config-en), var(--font-config-zh), var(--font-cjk-system);
+  --font-heading: var(--font-config-en), var(--font-config-zh), var(--font-cjk-system);
+  --font-page-heading:
+    var(--font-config-en), var(--font-config-zh-subset), var(--font-config-zh),
+    var(--font-cjk-system);
   --font-meta: var(--font-mono);
   --font-code: var(--font-mono);
   --font-ui-label: var(--font-mono);


### PR DESCRIPTION
## Summary

- Add site-level font config under `[config.fonts]` with `en`, `zh`, and `file`
- Move global font declarations into `src/styles/fonts.css`
- Switch the default Chinese font to ChillRoundM
- Generate the CJK UI subset from the configured font file
- Derive the subset output path automatically as `*-ui-subset.woff2`
- Keep full font warmup aligned with the configured font file

## Verification

- `bun run format:check`
- `bun run build`

close #82 