### PR TITLE
Fix responsive rendering for markdown tables

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -13,6 +13,8 @@ import tailwindcss from '@tailwindcss/vite';
 
 import expressiveCode from 'astro-expressive-code';
 
+import rehypeResponsiveTables from './src/utils/rehype-responsive-tables';
+
 const siteToml = parse(fs.readFileSync(new URL('./src/config/site.toml', import.meta.url), 'utf8'));
 const configuredSiteUrl = siteToml.config?.site?.url;
 const configuredMathRenderer = siteToml.config?.math?.render;
@@ -56,7 +58,10 @@ export default defineConfig({
   base: resolvedBase,
   markdown: {
     remarkPlugins: [remarkMath],
-    rehypePlugins: [mathRenderer === 'mathjax' ? rehypeMathjax : rehypeKatex],
+    rehypePlugins: [
+      mathRenderer === 'mathjax' ? rehypeMathjax : rehypeKatex,
+      rehypeResponsiveTables,
+    ],
   },
   integrations: [expressiveCode(), mdx(), sitemap()],
 

--- a/src/layouts/BlogArticle.astro
+++ b/src/layouts/BlogArticle.astro
@@ -343,6 +343,7 @@ const hasSidebar = shouldRenderSidebar && hasToc;
   .article-content {
     width: min(100%, var(--article-content-max));
     max-width: var(--article-content-max);
+    min-width: 0;
     color: var(--paper-ink);
     font-family: var(--font-article);
     font-size: 18px;

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -39,6 +39,7 @@ const palette = await getThemePalette();
       .prose {
         width: min(100%, var(--layout-reading-width));
         max-width: 100%;
+        min-width: 0;
         margin: auto;
         padding: 0 0 42px;
         color: var(--paper-ink);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -186,6 +186,23 @@ table {
   width: 100%;
 }
 
+.markdown-table-scroll {
+  max-width: 100%;
+  margin: 28px 0 30px;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.markdown-table-scroll table {
+  width: max-content;
+  min-width: 100%;
+  border-collapse: collapse;
+}
+
+.markdown-table-scroll th {
+  white-space: nowrap;
+}
+
 img {
   max-width: 100%;
   height: auto;

--- a/src/utils/rehype-responsive-tables.ts
+++ b/src/utils/rehype-responsive-tables.ts
@@ -1,0 +1,32 @@
+type HastNode = {
+  type?: string;
+  tagName?: string;
+  properties?: Record<string, unknown>;
+  children?: HastNode[];
+};
+
+function wrapTables(node?: HastNode) {
+  if (!node || !Array.isArray(node.children)) return;
+
+  node.children = node.children.map((child) => {
+    if (child.type === 'element' && child.tagName === 'table') {
+      return {
+        type: 'element',
+        tagName: 'div',
+        properties: {
+          className: ['markdown-table-scroll'],
+        },
+        children: [child],
+      };
+    }
+
+    wrapTables(child);
+    return child;
+  });
+}
+
+export default function rehypeResponsiveTables() {
+  return (tree: HastNode) => {
+    wrapTables(tree);
+  };
+}


### PR DESCRIPTION
- Add a rehype plugin that wraps Markdown/MDX tables in a scroll container.
- Apply scoped table overflow styles to article content layouts.
- Prevent wide tables from expanding the page width on narrow/mobile viewports.

close #90 