### PR TITLE
feat: add configurable blog UI localization

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -15,10 +15,22 @@ import expressiveCode from 'astro-expressive-code';
 
 import rehypeResponsiveTables from './src/utils/rehype-responsive-tables';
 
+/**
+ * @param {unknown} value
+ * @returns {value is Record<string, unknown>}
+ */
+const isRecord = (value) => typeof value === 'object' && value !== null && !Array.isArray(value);
+
 const siteToml = parse(fs.readFileSync(new URL('./src/config/site.toml', import.meta.url), 'utf8'));
-const configuredSiteUrl = siteToml.config?.site?.url;
-const configuredMathRenderer = siteToml.config?.math?.render;
+const configToml = isRecord(siteToml.config) ? siteToml.config : {};
+const siteConfig = isRecord(configToml.site) ? configToml.site : {};
+const mathConfig = isRecord(configToml.math) ? configToml.math : {};
+const configuredSiteUrl = siteConfig.url;
+const configuredMathRenderer = mathConfig.render;
 const mathRenderer = configuredMathRenderer === 'mathjax' ? 'mathjax' : 'katex';
+/**
+ * @param {unknown} value
+ */
 const normalizeSiteUrl = (value) => {
   if (typeof value !== 'string') return undefined;
 

--- a/scripts/fonts/subset-ui-font.ts
+++ b/scripts/fonts/subset-ui-font.ts
@@ -19,7 +19,14 @@ const subsetFontName = `${fontConfig.zh} UI Subset`;
 const contentSource = process.env.NAVFOLIO_CONTENT_SOURCE === 'docs' ? 'docs' : 'content';
 const contentRoot = contentSource === 'docs' ? 'src/docs' : 'src/content';
 
-const sourceDirs = ['src/pages', 'src/components', 'src/layouts', 'src/config'];
+const sourceDirs = [
+  'src/pages',
+  'src/components',
+  'src/layouts',
+  'src/config',
+  'src/utils',
+  'src/i18n',
+];
 const contentFrontmatterDirs = [
   `${contentRoot}/blog`,
   `${contentRoot}/projects`,

--- a/src/components/article/ArticleHeader.astro
+++ b/src/components/article/ArticleHeader.astro
@@ -4,7 +4,9 @@ import PageView from '../comments/PageView.astro';
 import FormattedDate from '../FormattedDate.astro';
 import Icon from '../Icon.astro';
 import MetadataItem from '../MetadataItem.astro';
+import { getSiteConfig } from '../../data/site';
 import { slugifyGroupName } from '../../utils/content-groups';
+import { getUiText } from '../../utils/ui-text';
 
 type TagLink = string | { name: string; slug: string };
 
@@ -43,7 +45,6 @@ const {
   pathname = Astro.url.pathname,
   showPageView = false,
 } = Astro.props;
-const wordCountLabel = `${wordCount.toLocaleString('en-US')} words`;
 const tagLinks = tags.map((tag) =>
   typeof tag === 'string' ? { name: tag, slug: slugifyGroupName(tag) } : tag,
 );
@@ -53,6 +54,8 @@ const hasSeries = series.length > 0;
 const hasGroups = hasCategories || hasSeries;
 const isArchiveHeader = variant === 'archive';
 const basePath = import.meta.env.BASE_URL.replace(/\/$/, '');
+const ui = getUiText(await getSiteConfig());
+const wordCountLabel = ui.article.wordCount(wordCount);
 ---
 
 <header
@@ -69,7 +72,7 @@ const basePath = import.meta.env.BASE_URL.replace(/\/$/, '');
           <h1 class="archive-title" data-pagefind-meta="title">
             {title}
           </h1>
-          <div class="meta-line" aria-label="Article metadata">
+          <div class="meta-line" aria-label={ui.article.metadata}>
             {date && (
               <MetadataItem kind="date" separated={false}>
                 <FormattedDate date={date} />
@@ -91,11 +94,11 @@ const basePath = import.meta.env.BASE_URL.replace(/\/$/, '');
             )}
           </div>
           {hasGroups && (
-            <div class="group-meta-line" aria-label="Article groups">
+            <div class="group-meta-line" aria-label={ui.article.groups}>
               {hasCategories && (
                 <span class="group-meta-item">
                   <Icon name="folder" size={15} />
-                  <span class="group-label">Categories</span>
+                  <span class="group-label">{ui.groups.categories}</span>
                   <span class="group-list">
                     {categories.map((category) => (
                       <a class="group-link" href={`${basePath}/blog/categories/${category.slug}/`}>
@@ -108,7 +111,7 @@ const basePath = import.meta.env.BASE_URL.replace(/\/$/, '');
               {hasSeries && (
                 <span class="group-meta-item">
                   <Icon name="layers" size={15} />
-                  <span class="group-label">Series</span>
+                  <span class="group-label">{ui.groups.series}</span>
                   <span class="group-list">
                     {series.map((item) => (
                       <a class="group-link" href={`${basePath}/blog/series/${item.slug}/`}>
@@ -133,7 +136,7 @@ const basePath = import.meta.env.BASE_URL.replace(/\/$/, '');
       <>
         <h1 data-pagefind-meta="title">{title}</h1>
 
-        <div class="meta-line" aria-label="Article metadata">
+        <div class="meta-line" aria-label={ui.article.metadata}>
           {date && (
             <MetadataItem kind="date" separated={false}>
               <FormattedDate date={date} />
@@ -155,11 +158,11 @@ const basePath = import.meta.env.BASE_URL.replace(/\/$/, '');
           )}
         </div>
         {hasGroups && (
-          <div class="group-meta-line" aria-label="Article groups">
+          <div class="group-meta-line" aria-label={ui.article.groups}>
             {hasCategories && (
               <span class="group-meta-item">
                 <Icon name="folder" size={15} />
-                <span class="group-label">Categories</span>
+                <span class="group-label">{ui.groups.categories}</span>
                 <span class="group-list">
                   {categories.map((category) => (
                     <a class="group-link" href={`${basePath}/blog/categories/${category.slug}/`}>
@@ -172,7 +175,7 @@ const basePath = import.meta.env.BASE_URL.replace(/\/$/, '');
             {hasSeries && (
               <span class="group-meta-item">
                 <Icon name="layers" size={15} />
-                <span class="group-label">Series</span>
+                <span class="group-label">{ui.groups.series}</span>
                 <span class="group-list">
                   {series.map((item) => (
                     <a class="group-link" href={`${basePath}/blog/series/${item.slug}/`}>

--- a/src/components/blog/BlogArchive.astro
+++ b/src/components/blog/BlogArchive.astro
@@ -4,8 +4,10 @@ import { ChevronsRight } from 'lucide-astro';
 import FormattedDate from '../FormattedDate.astro';
 import MetadataItem from '../MetadataItem.astro';
 import SmartImage from '../SmartImage.astro';
+import { getSiteConfig } from '../../data/site';
 import { slugifyGroupName } from '../../utils/content-groups';
 import { isStickyEntry } from '../../utils/content-dates';
+import { getUiText } from '../../utils/ui-text';
 
 type BlogPost = CollectionEntry<'blog'>;
 type CoverImageStyle = 'card' | 'mask';
@@ -49,6 +51,7 @@ const resolvedHeaderSubtitle = headerSubtitle ?? headerNote ?? defaultHeaderSubt
 const resolvedHeaderNote = headerSubtitle !== undefined ? headerNote : undefined;
 const basePath = import.meta.env.BASE_URL.replace(/\/$/, '');
 const hasPagination = page.lastPage > 1;
+const ui = getUiText(await getSiteConfig());
 
 function withBase(href: string) {
   if (href === '/') {
@@ -99,7 +102,7 @@ function getPageHref(pageNumber: number) {
                   <a class="title-link" href={withBase(`/blog/${post.id}/`)}>
                     {post.data.title}
                   </a>
-                  {isStickyEntry(post) && <span class="post-pin">Pinned</span>}
+                  {isStickyEntry(post) && <span class="post-pin">{ui.article.pinned}</span>}
                 </h2>
                 <div class="date">
                   <MetadataItem kind="date" separated={false}>
@@ -107,7 +110,7 @@ function getPageHref(pageNumber: number) {
                   </MetadataItem>
                   {post.data.categories.length > 0 && (
                     <MetadataItem kind="categories" class="post-groups">
-                      <span class="meta-label">Categories</span>
+                      <span class="meta-label">{ui.groups.categories}</span>
                       {post.data.categories.map((category) => (
                         <a
                           class="post-group"
@@ -120,7 +123,7 @@ function getPageHref(pageNumber: number) {
                   )}
                   {post.data.series.length > 0 && (
                     <MetadataItem kind="series" class="post-groups">
-                      <span class="meta-label">Series</span>
+                      <span class="meta-label">{ui.groups.series}</span>
                       {post.data.series.map((series) => (
                         <a
                           class="post-group"
@@ -161,15 +164,18 @@ function getPageHref(pageNumber: number) {
 </section>
 {
   hasPagination && (
-    <nav class="archive-pagination" aria-label="Blog pagination">
+    <nav class="archive-pagination" aria-label={ui.pagination.blog}>
       <a
         class:list={['pagination-link', { disabled: !page.url.prev }]}
         href={page.url.prev ? withBase(page.url.prev) : undefined}
         aria-disabled={!page.url.prev}
       >
-        Previous
+        {ui.pagination.previous}
       </a>
-      <div class="pagination-pages" aria-label={`Page ${page.currentPage} of ${page.lastPage}`}>
+      <div
+        class="pagination-pages"
+        aria-label={ui.pagination.page(page.currentPage, page.lastPage)}
+      >
         {Array.from({ length: page.lastPage }, (_, index) => {
           const pageNumber = index + 1;
           const isCurrent = pageNumber === page.currentPage;
@@ -190,7 +196,7 @@ function getPageHref(pageNumber: number) {
         href={page.url.next ? withBase(page.url.next) : undefined}
         aria-disabled={!page.url.next}
       >
-        Next
+        {ui.pagination.next}
       </a>
     </nav>
   )

--- a/src/components/blog/BlogTopNav.astro
+++ b/src/components/blog/BlogTopNav.astro
@@ -3,6 +3,7 @@ import { Github, ListTree, Menu, Moon, Sun } from 'lucide-astro';
 import SiteSearch from './SiteSearch.astro';
 import TocTree from './TocTree.astro';
 import { getSiteConfig } from '../../data/site';
+import { getUiText } from '../../utils/ui-text';
 import type { TocItem } from '../../utils/toc-tree';
 
 interface Props {
@@ -11,7 +12,9 @@ interface Props {
 }
 
 const { showTocIcon = false, tocItems = [] } = Astro.props;
-const { site, topNav, search } = await getSiteConfig();
+const siteConfig = await getSiteConfig();
+const { site, topNav, search } = siteConfig;
+const ui = getUiText(siteConfig);
 const links = topNav.links;
 const basePath = import.meta.env.BASE_URL.replace(/\/$/, '');
 const currentPathname =
@@ -58,7 +61,12 @@ const brandRouteLabel = activeRoute?.[1];
 const shouldShowTocAction = showTocIcon && tocItems.length > 0;
 ---
 
-<header class="blog-top-nav" data-pagefind-ignore>
+<header
+  class="blog-top-nav"
+  data-pagefind-ignore
+  data-toc-open-label={ui.toc.open}
+  data-toc-close-label={ui.toc.close}
+>
   <button
     class="mobile-menu-toggle"
     type="button"
@@ -143,10 +151,10 @@ const shouldShowTocAction = showTocIcon && tocItems.length > 0;
         <button
           class="toc-action"
           type="button"
-          aria-label="Open table of contents"
+          aria-label={ui.toc.open}
           aria-expanded="false"
           aria-controls="mobile-toc-menu"
-          title="Table of contents"
+          title={ui.toc.title}
           data-mobile-toc-trigger
         >
           <ListTree size={17} stroke-width={2} />
@@ -160,12 +168,12 @@ const shouldShowTocAction = showTocIcon && tocItems.length > 0;
       <nav
         class="mobile-toc-panel"
         id="mobile-toc-menu"
-        aria-label="Article table of contents"
+        aria-label={ui.toc.title}
         data-nav-toc-menu
         data-toc-root
         data-toc-scroll
       >
-        <p>Table of contents</p>
+        <p>{ui.toc.title}</p>
         <TocTree items={tocItems} idPrefix="nav-toc" navLink />
       </nav>
     )
@@ -257,12 +265,12 @@ const shouldShowTocAction = showTocIcon && tocItems.length > 0;
             return;
           }
 
+          const tocOpenLabel = header.dataset.tocOpenLabel ?? 'Open table of contents';
+          const tocCloseLabel = header.dataset.tocCloseLabel ?? 'Close table of contents';
+
           header.dataset.mobileTocOpen = open ? 'true' : 'false';
           tocTrigger.setAttribute('aria-expanded', String(open));
-          tocTrigger.setAttribute(
-            'aria-label',
-            open ? 'Close table of contents' : 'Open table of contents',
-          );
+          tocTrigger.setAttribute('aria-label', open ? tocCloseLabel : tocOpenLabel);
         };
 
         toggle.addEventListener('click', () => {

--- a/src/components/blog/CategoryCard.astro
+++ b/src/components/blog/CategoryCard.astro
@@ -1,4 +1,7 @@
 ---
+import { getSiteConfig } from '../../data/site';
+import { getUiText } from '../../utils/ui-text';
+
 interface Props {
   name: string;
   slug: string;
@@ -8,13 +11,13 @@ interface Props {
 const { name, slug, count } = Astro.props;
 const basePath = import.meta.env.BASE_URL.replace(/\/$/, '');
 const href = `${basePath}/blog/categories/${slug}/`;
-const articleLabel = count === 1 ? 'article' : 'articles';
+const ui = getUiText(await getSiteConfig());
 ---
 
 <a class="category-card" href={href}>
-  <span class="category-label">Category</span>
+  <span class="category-label">{ui.groups.category}</span>
   <strong>{name}</strong>
-  <span>{count} {articleLabel}</span>
+  <span>{ui.groups.articleCount(count)}</span>
 </a>
 
 <style>

--- a/src/components/blog/GroupNav.astro
+++ b/src/components/blog/GroupNav.astro
@@ -1,27 +1,30 @@
 ---
 import { getCollection } from 'astro:content';
+import { getSiteConfig } from '../../data/site';
 import { getAllCategories, getAllSeries } from '../../utils/content-groups';
+import { getUiText } from '../../utils/ui-text';
 
 const basePath = import.meta.env.BASE_URL.replace(/\/$/, '');
 const posts = await getCollection('blog');
 const categoryCount = getAllCategories(posts).length;
 const seriesCount = getAllSeries(posts).length;
+const ui = getUiText(await getSiteConfig());
 ---
 
-<nav class="group-nav" aria-label="Blog browsing groups">
+<nav class="group-nav" aria-label={ui.groups.blogBrowsingGroups}>
   <a href={`${basePath}/blog/categories/`}>
     <span>
-      Categories
+      {ui.groups.categories}
       <b>{categoryCount}</b>
     </span>
-    <small>Browse by topic</small>
+    <small>{ui.groups.browseByTopic}</small>
   </a>
   <a href={`${basePath}/blog/series/`}>
     <span>
-      Series
+      {ui.groups.series}
       <b>{seriesCount}</b>
     </span>
-    <small>Follow connected notes</small>
+    <small>{ui.groups.followConnectedNotes}</small>
   </a>
 </nav>
 

--- a/src/components/blog/RelatedPosts.astro
+++ b/src/components/blog/RelatedPosts.astro
@@ -2,6 +2,8 @@
 import type { CollectionEntry } from 'astro:content';
 import FormattedDate from '../FormattedDate.astro';
 import SmartImage from '../SmartImage.astro';
+import { getSiteConfig } from '../../data/site';
+import { getUiText } from '../../utils/ui-text';
 
 interface Props {
   posts: CollectionEntry<'blog'>[];
@@ -10,6 +12,8 @@ interface Props {
 
 const { posts, class: className } = Astro.props;
 const basePath = import.meta.env.BASE_URL.replace(/\/$/, '');
+const siteConfig = await getSiteConfig();
+const ui = getUiText(siteConfig);
 
 function withBase(href: string) {
   if (href === '/') {
@@ -21,7 +25,7 @@ function withBase(href: string) {
 ---
 
 <aside class:list={['related-posts', 'blog-card', className]}>
-  <h2>More from navfolio</h2>
+  <h2>{ui.article.moreFromSite(siteConfig.site.title)}</h2>
   <div class="related-list">
     {
       posts.map((post) => (

--- a/src/components/blog/SeriesCard.astro
+++ b/src/components/blog/SeriesCard.astro
@@ -2,6 +2,8 @@
 import type { CollectionEntry } from 'astro:content';
 import FormattedDate from '../FormattedDate.astro';
 import SeriesProgress from './SeriesProgress.astro';
+import { getSiteConfig } from '../../data/site';
+import { getUiText } from '../../utils/ui-text';
 
 interface Props {
   name: string;
@@ -12,12 +14,13 @@ interface Props {
 const { name, slug, posts } = Astro.props;
 const basePath = import.meta.env.BASE_URL.replace(/\/$/, '');
 const href = `${basePath}/blog/series/${slug}/`;
+const ui = getUiText(await getSiteConfig());
 ---
 
 <article class="series-card">
   <div class="series-heading">
     <div>
-      <p>Series</p>
+      <p>{ui.groups.series}</p>
       <h2><a href={href}>{name}</a></h2>
     </div>
     <SeriesProgress current={posts.length} total={posts.length} />
@@ -41,7 +44,7 @@ const href = `${basePath}/blog/series/${slug}/`;
   {
     posts.length > 4 && (
       <a class="series-more" href={href}>
-        View {posts.length - 4} more
+        {ui.groups.viewMore(posts.length - 4)}
       </a>
     )
   }

--- a/src/components/blog/SeriesProgress.astro
+++ b/src/components/blog/SeriesProgress.astro
@@ -1,4 +1,7 @@
 ---
+import { getSiteConfig } from '../../data/site';
+import { getUiText } from '../../utils/ui-text';
+
 interface Props {
   current: number;
   total: number;
@@ -7,10 +10,11 @@ interface Props {
 const { current, total } = Astro.props;
 const safeTotal = Math.max(1, total);
 const percent = Math.round((current / safeTotal) * 100);
+const ui = getUiText(await getSiteConfig());
 ---
 
-<span class="series-progress" aria-label={`${current} published articles`}>
-  <span class="series-progress-copy">{current} published</span>
+<span class="series-progress" aria-label={ui.groups.publishedArticles(current)}>
+  <span class="series-progress-copy">{ui.groups.publishedCount(current)}</span>
   <span class="series-progress-track" aria-hidden="true">
     <span style={`width: ${percent}%`}></span>
   </span>

--- a/src/components/blog/SiteSearch.astro
+++ b/src/components/blog/SiteSearch.astro
@@ -1,12 +1,14 @@
 ---
 import { Search, X } from 'lucide-astro';
-import type { SiteSearch as SiteSearchConfig } from '../../data/site';
+import { getSiteConfig, type SiteSearch as SiteSearchConfig } from '../../data/site';
+import { getUiText } from '../../utils/ui-text';
 
 interface Props {
   search: SiteSearchConfig;
 }
 
 const { search } = Astro.props;
+const ui = getUiText(await getSiteConfig());
 const shortcutLabel = search.shortcut === 'mod+k' ? 'Ctrl K / Cmd K' : search.shortcut;
 ---
 
@@ -14,19 +16,25 @@ const shortcutLabel = search.shortcut === 'mod+k' ? 'Ctrl K / Cmd K' : search.sh
   class="site-search"
   data-site-search-root
   data-search-max-results={search.maxResults}
-  data-search-idle-label="Start typing to search."
-  data-search-loading-label="Searching..."
-  data-search-empty-label="No notes found."
-  data-search-unavailable-label="Search index is not available yet. Run a production build first."
+  data-search-idle-label={ui.search.idle}
+  data-search-loading-label={ui.search.loading}
+  data-search-empty-label={ui.search.empty}
+  data-search-unavailable-label={ui.search.unavailable}
+  data-search-kind-blog-note={ui.search.resultKinds.blogNote}
+  data-search-kind-blog-index={ui.search.resultKinds.blogIndex}
+  data-search-kind-vibe={ui.search.resultKinds.vibe}
+  data-search-kind-project={ui.search.resultKinds.project}
+  data-search-kind-page={ui.search.resultKinds.page}
+  data-search-match-label={ui.search.matchedPassage}
   data-pagefind-ignore
 >
   <button
     class="site-search-trigger"
     type="button"
-    aria-label="Search site"
+    aria-label={ui.search.trigger}
     aria-expanded="false"
     aria-controls="site-search-dialog"
-    title={`Search (${shortcutLabel})`}
+    title={`${ui.search.title} (${shortcutLabel})`}
     data-site-search-trigger
   >
     <Search size={17} stroke-width={2} />
@@ -43,14 +51,14 @@ const shortcutLabel = search.shortcut === 'mod+k' ? 'Ctrl K / Cmd K' : search.sh
     >
       <header class="site-search-head">
         <div>
-          <p id="site-search-title">Search</p>
+          <p id="site-search-title">{ui.search.title}</p>
           <span>{shortcutLabel}</span>
         </div>
         <button
           class="site-search-close"
           type="button"
-          aria-label="Close search"
-          title="Close search"
+          aria-label={ui.search.close}
+          title={ui.search.close}
           data-site-search-close
         >
           <X size={17} stroke-width={2} />
@@ -68,7 +76,7 @@ const shortcutLabel = search.shortcut === 'mod+k' ? 'Ctrl K / Cmd K' : search.sh
         />
       </label>
 
-      <p class="site-search-status" data-site-search-status>Start typing to search.</p>
+      <p class="site-search-status" data-site-search-status>{ui.search.idle}</p>
       <ol class="site-search-results" data-site-search-results></ol>
     </section>
   </div>

--- a/src/components/blog/TableOfContents.astro
+++ b/src/components/blog/TableOfContents.astro
@@ -1,6 +1,8 @@
 ---
 import TocTree from './TocTree.astro';
+import { getSiteConfig } from '../../data/site';
 import { countTocItems, type TocItem } from '../../utils/toc-tree';
+import { getUiText } from '../../utils/ui-text';
 
 interface Props {
   items: TocItem[];
@@ -15,19 +17,24 @@ const hasItems = items.length > 0;
 const canCollapse = collapsible && countTocItems(items) > 3;
 const listId = collapsible ? 'mobile-article-toc-list' : undefined;
 const treeIdPrefix = collapsible ? 'article-toc' : 'sidebar-toc';
+const ui = getUiText(await getSiteConfig());
 ---
 
 {
   hasItems && (
     <nav
       class:list={['toc-card', 'blog-card', { compact, collapsible, 'can-collapse': canCollapse }]}
-      aria-label="Table of contents"
+      aria-label={ui.toc.title}
       data-toc-root
       data-font={font}
       data-mobile-toc={collapsible ? '' : undefined}
       data-expanded={collapsible ? 'false' : undefined}
+      data-expand-aria-label={ui.toc.expand}
+      data-collapse-aria-label={ui.toc.collapse}
+      data-expand-label={ui.toc.showAll}
+      data-collapse-label={ui.toc.collapseButton}
     >
-      <h2>Table of contents</h2>
+      <h2>{ui.toc.title}</h2>
       <div id={listId} class="toc-list-wrap" data-toc-scroll>
         <TocTree items={items} idPrefix={treeIdPrefix} />
       </div>
@@ -35,12 +42,12 @@ const treeIdPrefix = collapsible ? 'article-toc' : 'sidebar-toc';
         <button
           class="toc-expand"
           type="button"
-          aria-label="Expand table of contents"
+          aria-label={ui.toc.expand}
           aria-expanded="false"
           aria-controls={listId}
           data-toc-expand
         >
-          <span data-expand-label>Show all</span>
+          <span data-expand-label>{ui.toc.showAll}</span>
           <i aria-hidden="true" />
         </button>
       )}
@@ -71,10 +78,14 @@ const treeIdPrefix = collapsible ? 'article-toc' : 'sidebar-toc';
         button.setAttribute('aria-expanded', String(nextExpanded));
         button.setAttribute(
           'aria-label',
-          nextExpanded ? 'Collapse table of contents' : 'Expand table of contents',
+          nextExpanded
+            ? (toc.dataset.collapseAriaLabel ?? 'Collapse table of contents')
+            : (toc.dataset.expandAriaLabel ?? 'Expand table of contents'),
         );
         if (label) {
-          label.textContent = nextExpanded ? 'Collapse' : 'Show all';
+          label.textContent = nextExpanded
+            ? (toc.dataset.collapseLabel ?? 'Collapse')
+            : (toc.dataset.expandLabel ?? 'Show all');
         }
       });
     }

--- a/src/components/cards/ConnectCard.astro
+++ b/src/components/cards/ConnectCard.astro
@@ -84,6 +84,7 @@ const { links } = Astro.props as { links: ConnectLink[] };
   .connect-list {
     display: flex;
     flex-wrap: wrap;
+    justify-content: flex-end;
     gap: 8px;
   }
 
@@ -216,7 +217,6 @@ const { links } = Astro.props as { links: ConnectLink[] };
 
     .connect-list {
       gap: 7px;
-      justify-content: center;
     }
   }
 </style>

--- a/src/components/cards/ProfileCard.astro
+++ b/src/components/cards/ProfileCard.astro
@@ -5,11 +5,8 @@ interface Profile {
   name: string;
   handle: string;
   role: string;
-  company: string;
-  location: string;
   email: string;
   website: string;
-  meta: string;
   avatar: string;
 }
 

--- a/src/components/cards/QuoteCard.astro
+++ b/src/components/cards/QuoteCard.astro
@@ -1,7 +1,6 @@
 ---
 interface Quote {
   text: string[];
-  image: string;
 }
 
 const { quote } = Astro.props as { quote: Quote };
@@ -12,19 +11,12 @@ const { quote } = Astro.props as { quote: Quote };
   <blockquote>
     {quote.text.map((line) => <span>{line}</span>)}
   </blockquote>
-  <img
-    src={quote.image}
-    alt="desk workspace illustration"
-    width="410"
-    height="230"
-    loading="eager"
-  />
 </article>
 
 <style>
   .quote-card {
     display: grid;
-    grid-template-columns: 48px minmax(0, 1fr) minmax(210px, 0.84fr);
+    grid-template-columns: 48px minmax(0, 1fr);
     gap: 14px;
     align-items: center;
     min-height: 250px;
@@ -53,15 +45,6 @@ const { quote } = Astro.props as { quote: Quote };
     line-height: 1.3;
   }
 
-  img {
-    width: 100%;
-    height: 206px;
-    object-fit: cover;
-    object-position: center;
-    border-radius: 8px;
-    filter: saturate(0.94);
-  }
-
   @media (max-width: 640px) {
     .quote-card {
       grid-template-columns: 1fr;
@@ -74,10 +57,6 @@ const { quote } = Astro.props as { quote: Quote };
 
     blockquote {
       font-size: 1.08rem;
-    }
-
-    img {
-      height: 170px;
     }
   }
 </style>

--- a/src/components/widgets/BlogHeatmap.astro
+++ b/src/components/widgets/BlogHeatmap.astro
@@ -1,7 +1,9 @@
 ---
 import { getCollection } from 'astro:content';
 import Icon from '../Icon.astro';
+import { getSiteConfig } from '../../data/site';
 import { createRecentBlogHeatmap, type HeatmapDay } from '../../utils/blog-heatmap';
+import { getUiText } from '../../utils/ui-text';
 
 interface Props {
   weeks?: number;
@@ -22,21 +24,22 @@ const {
 } = Astro.props;
 const posts = await getCollection('blog', ({ data }) => !excludeDraft || !data.draft);
 const heatmap = createRecentBlogHeatmap(posts, weeks, latestCount, startDate);
+const ui = getUiText(await getSiteConfig());
 const heatmapLabel = startDate
-  ? `Writing activity since ${heatmap.startDate}`
-  : `Recent ${heatmap.weeks} weeks writing activity`;
-const formatDate = new Intl.DateTimeFormat('en', {
+  ? ui.heatmap.writingSince(heatmap.startDate)
+  : ui.heatmap.recentWeeks(heatmap.weeks);
+const formatDate = new Intl.DateTimeFormat(ui.locale, {
   month: 'short',
   day: 'numeric',
   year: 'numeric',
 });
 
 function getPostLabel(count: number) {
-  return `${count} ${count === 1 ? 'post' : 'posts'}`;
+  return ui.heatmap.postCount(count);
 }
 
 function getDayTitle(day: HeatmapDay) {
-  if (day.isFuture) return `${day.date}: upcoming`;
+  if (day.isFuture) return `${day.date}: ${ui.heatmap.upcoming}`;
 
   const titleLines = day.posts.slice(0, 5).map((post) => `- ${post.title}`);
   const overflowLine = day.posts.length > 5 ? ['...'] : [];
@@ -57,25 +60,29 @@ function getDayHref(day: HeatmapDay) {
   <div class="stats-row">
     <div class="stat-item">
       <strong>{heatmap.totalPosts}</strong>
-      <span>Total posts</span>
+      <span>{ui.heatmap.totalPosts}</span>
     </div>
     <div class="stat-item">
       <strong>{heatmap.activeDays}</strong>
-      <span>Active days</span>
+      <span>{ui.heatmap.activeDays}</span>
     </div>
     <div class="stat-item">
       <strong>{heatmap.currentStreak}</strong>
-      <span>Day streak</span>
+      <span>{ui.heatmap.dayStreak}</span>
     </div>
   </div>
 
   {
     showLatest && heatmap.latestPosts.length > 0 && (
-      <aside class="latest-tip" aria-label="Latest published posts">
-        <strong>Latest</strong>
+      <aside class="latest-tip" aria-label={ui.heatmap.latestPublishedPosts}>
+        <strong>{ui.heatmap.latest}</strong>
         <div class="latest-list">
           {heatmap.latestPosts.map((post) => (
-            <a class="latest-link" href={post.href} aria-label={`Open latest post: ${post.title}`}>
+            <a
+              class="latest-link"
+              href={post.href}
+              aria-label={ui.heatmap.openLatestPost(post.title)}
+            >
               <em>{post.title}</em>
               <time datetime={post.date.toISOString()}>{formatDate.format(post.date)}</time>
               <span class="latest-icon" aria-hidden="true">
@@ -90,9 +97,7 @@ function getDayHref(day: HeatmapDay) {
 
   <div class="rhythm-grid" aria-label={heatmapLabel}>
     <div class="weekday-column" aria-hidden="true">
-      <span>Mon</span>
-      <span>Wed</span>
-      <span>Fri</span>
+      {ui.heatmap.weekdays.map((weekday) => <span>{weekday}</span>)}
     </div>
 
     <div class="heatmap-cells" style={`--week-count: ${heatmap.weeks};`}>
@@ -126,9 +131,9 @@ function getDayHref(day: HeatmapDay) {
   </div>
 
   <footer>
-    <span>Less</span>
+    <span>{ui.heatmap.less}</span>
     {[0, 1, 2, 3, 4].map((level) => <i class={`heatmap-cell level-${level}`} />)}
-    <span>More</span>
+    <span>{ui.heatmap.more}</span>
   </footer>
 </article>
 

--- a/src/components/widgets/DoingCard.astro
+++ b/src/components/widgets/DoingCard.astro
@@ -1,5 +1,7 @@
 ---
 import Icon from '../Icon.astro';
+import { getSiteConfig } from '../../data/site';
+import { getUiText } from '../../utils/ui-text';
 
 interface DoingItem {
   text: string;
@@ -7,10 +9,11 @@ interface DoingItem {
 }
 
 const { items } = Astro.props as { items: DoingItem[] };
+const ui = getUiText(await getSiteConfig());
 ---
 
 <article class="glass-card doing-card">
-  <h2><Icon name="calendar" /> Recently</h2>
+  <h2><Icon name="calendar" /> {ui.doing.recently}</h2>
   <ul>
     {
       items.map((item) => (

--- a/src/config/site.toml
+++ b/src/config/site.toml
@@ -11,6 +11,8 @@ footerNote = "Released as an open-source starter."
 # 可用色盘：
 # green-soft, green-vivid, rose-soft, pink-soft, purple-soft, blue-soft, orange-soft, brown-soft
 palette = "green-soft"
+# 原生 UI 语言。可用值：en、zh-CN、zh-TW。未知值会回退到 en。
+lang = "en"
 
 [config.fonts]
 # 英文与代码感 UI 字体
@@ -114,12 +116,9 @@ comment = true
 name = "navfolio"
 handle = "@navfolio"
 role = "A Cat Developer"
-company = "Independent Studio"
-location = "Remote"
 email = "hello@navfolio.site"
 website = "https://astro.navfolio.site/"
 github = "https://github.com/dodolalorc/astro-navfolio"
-meta = "Open-source maintainer"
 avatar = "/images/logo.png"
 
 [[config.topNav.links]]
@@ -150,7 +149,6 @@ text = [
   "Showcase your story,",
   "and keep everything in one place.",
 ]
-image = "/images/logo-with-name.png"
 
 [config.home.intro]
 title = "here is navfolio"
@@ -163,7 +161,6 @@ body = [
   "Navfolio 专注于轻量级组织、流畅的阅读体验，以及对开发者友好的美学设计。",
   "它不像一份简历，更像是一个属于你自己的个人操作系统——承载想法、项目、笔记与网络足迹。",
 ]
-image = "/images/logo-cat.png"
 
 [config.home.latest]
 count = 1
@@ -212,7 +209,7 @@ copy = false
 [[config.home.links]]
 label = "X"
 icon = "x"
-tooltip = "" # Empty tooltip hides this link item.
+tooltip = "" # 留空会隐藏这个链接项。
 copy = false
 
 [[config.home.links]]

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -276,10 +276,12 @@ const siteConfig = defineCollection({
     theme: z
       .object({
         palette: paletteSchema.optional().default('green-soft'),
+        lang: z.string().optional().default('en'),
       })
       .optional()
       .default({
         palette: 'green-soft',
+        lang: 'en',
       }),
     fonts: z
       .object({
@@ -356,12 +358,9 @@ const siteConfig = defineCollection({
       name: z.string(),
       handle: z.string(),
       role: z.string(),
-      company: z.string(),
-      location: z.string(),
       email: z.email(),
       website: z.url(),
       github: z.url(),
-      meta: z.string(),
       avatar: z.string(),
     }),
     topNav: z.object({
@@ -392,13 +391,11 @@ const siteConfig = defineCollection({
     home: z.object({
       quote: z.object({
         text: z.array(z.string()).min(1),
-        image: z.string(),
       }),
       intro: z.object({
         title: z.string(),
         name: z.string(),
         body: z.array(z.string()).min(1),
-        image: z.string(),
       }),
       latest: z
         .object({

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -16,18 +16,12 @@ export async function getThemePalette() {
   return theme.palette;
 }
 
-export async function getCodeConfig() {
-  const { code } = await getSiteConfig();
-
-  return code;
-}
-
 export type SiteConfig = Awaited<ReturnType<typeof getSiteConfig>>;
 export type ThemePalette = SiteConfig['theme']['palette'];
 export type SiteProfile = SiteConfig['profile'];
+export type SiteTheme = SiteConfig['theme'];
 export type SiteLink = SiteConfig['topNav']['links'][number];
 export type SiteSearch = SiteConfig['search'];
-export type SiteCode = SiteConfig['code'];
 export type SiteMath = SiteConfig['math'];
 export type SiteFonts = SiteConfig['fonts'];
 export type SitePages = SiteConfig['pages'];

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,0 +1,102 @@
+{
+  "locale": "en",
+  "doing": {
+    "recently": "Recently"
+  },
+  "heatmap": {
+    "totalPosts": "Total posts",
+    "activeDays": "Active days",
+    "dayStreak": "Day streak",
+    "latest": "Latest",
+    "latestPublishedPosts": "Latest published posts",
+    "openLatestPost": "Open latest post: {title}",
+    "less": "Less",
+    "more": "More",
+    "weekdays": ["Mon", "Wed", "Fri"],
+    "writingSince": "Writing activity since {date}",
+    "recentWeeks": "Recent {weeks} weeks writing activity",
+    "upcoming": "upcoming",
+    "postCount": {
+      "one": "{count} post",
+      "other": "{count} posts"
+    }
+  },
+  "groups": {
+    "categories": "Categories",
+    "series": "Series",
+    "category": "Category",
+    "tag": "Tag",
+    "back": "Back",
+    "browseByTopic": "Browse by topic",
+    "followConnectedNotes": "Follow connected notes",
+    "blogBrowsingGroups": "Blog browsing groups",
+    "emptyCategories": "No categories have been added yet.",
+    "emptySeries": "No series have been added yet.",
+    "articleCount": {
+      "one": "{count} article",
+      "other": "{count} articles"
+    },
+    "categoryNote": {
+      "one": "{count} article in this topic.",
+      "other": "{count} articles in this topic."
+    },
+    "seriesNote": {
+      "one": "{count} article in reading order.",
+      "other": "{count} articles in reading order."
+    },
+    "tagNote": {
+      "one": "{count} article with this tag.",
+      "other": "{count} articles with this tag."
+    },
+    "publishedCount": "{count} published",
+    "publishedArticles": {
+      "one": "{count} published article",
+      "other": "{count} published articles"
+    },
+    "viewMore": "View {count} more"
+  },
+  "article": {
+    "metadata": "Article metadata",
+    "groups": "Article groups",
+    "readingTools": "Reading tools",
+    "wordCount": "{count} words",
+    "readingTime": "{minutes} min read",
+    "moreInSeries": "More in {name}",
+    "previousInSeries": "Previous in {name}",
+    "nextInSeries": "Next in {name}",
+    "pinned": "Pinned",
+    "moreFromSite": "More from {siteTitle}"
+  },
+  "toc": {
+    "title": "Table of contents",
+    "open": "Open table of contents",
+    "close": "Close table of contents",
+    "expand": "Expand table of contents",
+    "collapse": "Collapse table of contents",
+    "showAll": "Show all",
+    "collapseButton": "Collapse"
+  },
+  "pagination": {
+    "blog": "Blog pagination",
+    "previous": "Previous",
+    "next": "Next",
+    "page": "Page {current} of {total}"
+  },
+  "search": {
+    "title": "Search",
+    "trigger": "Search site",
+    "close": "Close search",
+    "idle": "Start typing to search.",
+    "loading": "Searching...",
+    "empty": "No notes found.",
+    "unavailable": "Search index is not available yet. Run a production build first.",
+    "resultKinds": {
+      "blogNote": "Blog note",
+      "blogIndex": "Blog index",
+      "vibe": "Vibe",
+      "project": "Project",
+      "page": "Page"
+    },
+    "matchedPassage": "Matched passage"
+  }
+}

--- a/src/i18n/zh-CN.json
+++ b/src/i18n/zh-CN.json
@@ -1,0 +1,84 @@
+{
+  "locale": "zh-CN",
+  "doing": {
+    "recently": "最近"
+  },
+  "heatmap": {
+    "totalPosts": "总文章",
+    "activeDays": "活跃天数",
+    "dayStreak": "连续天数",
+    "latest": "最新",
+    "latestPublishedPosts": "最新发布文章",
+    "openLatestPost": "打开最新文章：{title}",
+    "less": "少",
+    "more": "多",
+    "weekdays": ["周一", "周三", "周五"],
+    "writingSince": "自 {date} 起的写作活动",
+    "recentWeeks": "最近 {weeks} 周写作活动",
+    "upcoming": "未来",
+    "postCount": "{count} 篇文章"
+  },
+  "groups": {
+    "categories": "分类",
+    "series": "系列",
+    "category": "分类",
+    "tag": "标签",
+    "back": "返回",
+    "browseByTopic": "按主题浏览",
+    "followConnectedNotes": "阅读连续笔记",
+    "blogBrowsingGroups": "博客浏览分组",
+    "emptyCategories": "还没有添加分类。",
+    "emptySeries": "还没有添加系列。",
+    "articleCount": "{count} 篇文章",
+    "categoryNote": "这个主题下有 {count} 篇文章。",
+    "seriesNote": "按阅读顺序排列，共 {count} 篇文章。",
+    "tagNote": "带有这个标签的文章共 {count} 篇。",
+    "publishedCount": "已发布 {count} 篇",
+    "publishedArticles": "已发布 {count} 篇文章",
+    "viewMore": "查看更多 {count} 篇"
+  },
+  "article": {
+    "metadata": "文章元信息",
+    "groups": "文章分组",
+    "readingTools": "阅读工具",
+    "wordCount": "{count} 字",
+    "readingTime": "{minutes} 分钟阅读",
+    "moreInSeries": "{name} 系列更多文章",
+    "previousInSeries": "{name} 上一篇",
+    "nextInSeries": "{name} 下一篇",
+    "pinned": "置顶",
+    "moreFromSite": "{siteTitle} 的更多文章"
+  },
+  "toc": {
+    "title": "目录",
+    "open": "打开目录",
+    "close": "关闭目录",
+    "expand": "展开目录",
+    "collapse": "收起目录",
+    "showAll": "显示全部",
+    "collapseButton": "收起"
+  },
+  "pagination": {
+    "blog": "博客分页",
+    "previous": "上一页",
+    "next": "下一页",
+    "page": "第 {current} 页，共 {total} 页"
+  },
+  "search": {
+    "title": "搜索",
+    "trigger": "搜索站点",
+    "close": "关闭搜索",
+    "idle": "输入关键词开始搜索。",
+    "loading": "搜索中...",
+    "empty": "没有找到笔记。",
+    "unavailable": "搜索索引还不可用。请先运行生产构建。",
+    "resultKinds": {
+      "blogNote": "博客文章",
+      "blogIndex": "博客索引",
+      "vibe": "Vibe",
+      "project": "项目",
+      "page": "页面"
+    },
+    "matchedPassage": "匹配段落"
+  }
+}

--- a/src/i18n/zh-TW.json
+++ b/src/i18n/zh-TW.json
@@ -1,0 +1,84 @@
+{
+  "locale": "zh-TW",
+  "doing": {
+    "recently": "最近"
+  },
+  "heatmap": {
+    "totalPosts": "總文章",
+    "activeDays": "活躍天數",
+    "dayStreak": "連續天數",
+    "latest": "最新",
+    "latestPublishedPosts": "最新發布文章",
+    "openLatestPost": "開啟最新文章：{title}",
+    "less": "少",
+    "more": "多",
+    "weekdays": ["週一", "週三", "週五"],
+    "writingSince": "自 {date} 起的寫作活動",
+    "recentWeeks": "最近 {weeks} 週寫作活動",
+    "upcoming": "未來",
+    "postCount": "{count} 篇文章"
+  },
+  "groups": {
+    "categories": "分類",
+    "series": "系列",
+    "category": "分類",
+    "tag": "標籤",
+    "back": "返回",
+    "browseByTopic": "按主題瀏覽",
+    "followConnectedNotes": "閱讀連續筆記",
+    "blogBrowsingGroups": "部落格瀏覽分組",
+    "emptyCategories": "還沒有新增分類。",
+    "emptySeries": "還沒有新增系列。",
+    "articleCount": "{count} 篇文章",
+    "categoryNote": "這個主題下有 {count} 篇文章。",
+    "seriesNote": "按閱讀順序排列，共 {count} 篇文章。",
+    "tagNote": "帶有這個標籤的文章共 {count} 篇。",
+    "publishedCount": "已發布 {count} 篇",
+    "publishedArticles": "已發布 {count} 篇文章",
+    "viewMore": "查看更多 {count} 篇"
+  },
+  "article": {
+    "metadata": "文章中繼資訊",
+    "groups": "文章分組",
+    "readingTools": "閱讀工具",
+    "wordCount": "{count} 字",
+    "readingTime": "{minutes} 分鐘閱讀",
+    "moreInSeries": "{name} 系列更多文章",
+    "previousInSeries": "{name} 上一篇",
+    "nextInSeries": "{name} 下一篇",
+    "pinned": "置頂",
+    "moreFromSite": "{siteTitle} 的更多文章"
+  },
+  "toc": {
+    "title": "目錄",
+    "open": "開啟目錄",
+    "close": "關閉目錄",
+    "expand": "展開目錄",
+    "collapse": "收合目錄",
+    "showAll": "顯示全部",
+    "collapseButton": "收合"
+  },
+  "pagination": {
+    "blog": "部落格分頁",
+    "previous": "上一頁",
+    "next": "下一頁",
+    "page": "第 {current} 頁，共 {total} 頁"
+  },
+  "search": {
+    "title": "搜尋",
+    "trigger": "搜尋站點",
+    "close": "關閉搜尋",
+    "idle": "輸入關鍵字開始搜尋。",
+    "loading": "搜尋中...",
+    "empty": "沒有找到筆記。",
+    "unavailable": "搜尋索引尚不可用。請先執行生產建置。",
+    "resultKinds": {
+      "blogNote": "部落格文章",
+      "blogIndex": "部落格索引",
+      "vibe": "Vibe",
+      "project": "專案",
+      "page": "頁面"
+    },
+    "matchedPassage": "匹配段落"
+  }
+}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -3,7 +3,8 @@ import BaseHead from '../components/BaseHead.astro';
 import BlogTopNav from '../components/blog/BlogTopNav.astro';
 import FullFontWarmup from '../components/FullFontWarmup.astro';
 import ScrollToTopButton from '../components/ScrollToTopButton.astro';
-import { getThemePalette } from '../data/site';
+import { getSiteConfig } from '../data/site';
+import { getHtmlLang } from '../utils/ui-text';
 
 interface Props {
   title: string;
@@ -11,11 +12,13 @@ interface Props {
 }
 
 const { title, description } = Astro.props;
-const palette = await getThemePalette();
+const siteConfig = await getSiteConfig();
+const palette = siteConfig.theme.palette;
+const htmlLang = getHtmlLang(siteConfig);
 ---
 
 <!doctype html>
-<html lang="zh-CN" data-palette={palette}>
+<html lang={htmlLang} data-palette={palette}>
   <head>
     <BaseHead title={title} description={description} />
   </head>

--- a/src/layouts/BlogArticle.astro
+++ b/src/layouts/BlogArticle.astro
@@ -13,9 +13,12 @@ import { resolveCommentsConfig } from '../utils/comments';
 import { sortByDateDesc } from '../utils/content-dates';
 import { getSeriesContext, slugifyGroupName } from '../utils/content-groups';
 import { buildTocTree, countTocItems } from '../utils/toc-tree';
+import { getUiText } from '../utils/ui-text';
 
-const { comments: rawComments } = await getSiteConfig();
+const siteConfig = await getSiteConfig();
+const { comments: rawComments } = siteConfig;
 const comments = resolveCommentsConfig(rawComments);
+const ui = getUiText(siteConfig);
 
 type SidebarConfig = {
   enable?: boolean;
@@ -88,7 +91,7 @@ const cjkChars =
   bodyText.match(/[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/gu) ?? [];
 const wordCount = englishWords.length + cjkChars.length;
 const readingMinutes = Math.max(1, Math.ceil(englishWords.length / 220 + cjkChars.length / 500));
-const readingTime = `${readingMinutes} min read`;
+const readingTime = ui.article.readingTime(readingMinutes);
 const tags = post.data.tags ?? [];
 const tagLinks = tags.map((name) => ({
   name,
@@ -170,7 +173,7 @@ const hasSidebar = shouldRenderSidebar && hasToc;
 
           {
             hasToc && (
-              <section class="mobile-article-toc" aria-label="Article table of contents">
+              <section class="mobile-article-toc" aria-label={ui.toc.title}>
                 <TableOfContents items={tocItems} compact collapsible font={contentFont} />
               </section>
             )
@@ -185,10 +188,13 @@ const hasSidebar = shouldRenderSidebar && hasToc;
 
           {
             seriesContext && (seriesContext.prev || seriesContext.next) && (
-              <nav class="series-neighbor-nav" aria-label={`More in ${seriesContext.name}`}>
+              <nav
+                class="series-neighbor-nav"
+                aria-label={ui.article.moreInSeries(seriesContext.name)}
+              >
                 {seriesContext.prev ? (
                   <a href={`${basePath}/blog/${seriesContext.prev.id}/`}>
-                    <small>Previous in {seriesContext.name}</small>
+                    <small>{ui.article.previousInSeries(seriesContext.name)}</small>
                     <span>{seriesContext.prev.data.title}</span>
                   </a>
                 ) : (
@@ -196,7 +202,7 @@ const hasSidebar = shouldRenderSidebar && hasToc;
                 )}
                 {seriesContext.next ? (
                   <a href={`${basePath}/blog/${seriesContext.next.id}/`} class="next">
-                    <small>Next in {seriesContext.name}</small>
+                    <small>{ui.article.nextInSeries(seriesContext.name)}</small>
                     <span>{seriesContext.next.data.title}</span>
                   </a>
                 ) : (
@@ -212,7 +218,7 @@ const hasSidebar = shouldRenderSidebar && hasToc;
 
       {
         hasSidebar && (
-          <aside class="right-sidebar" aria-label="Reading tools">
+          <aside class="right-sidebar" aria-label={ui.article.readingTools}>
             <div class="right-sidebar-inner">
               {hasToc && <TableOfContents items={tocItems} font={contentFont} />}
             </div>

--- a/src/layouts/BlogArticle.astro
+++ b/src/layouts/BlogArticle.astro
@@ -137,7 +137,7 @@ const hasSidebar = shouldRenderSidebar && hasToc;
 ---
 
 <!doctype html>
-<html lang="zh-CN" data-palette={palette}>
+<html lang={ui.locale} data-palette={palette}>
   <head>
     <BaseHead title={title} description={description} />
     {

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -6,15 +6,18 @@ import FormattedDate from '../components/FormattedDate.astro';
 import ScrollToTopButton from '../components/ScrollToTopButton.astro';
 import SmartImage from '../components/SmartImage.astro';
 import BlogTopNav from '../components/blog/BlogTopNav.astro';
-import { getThemePalette } from '../data/site';
+import { getSiteConfig } from '../data/site';
+import { getHtmlLang } from '../utils/ui-text';
 
 type Props = CollectionEntry<'blog'>['data'];
 
 const { title, description, date, heroImage } = Astro.props;
-const palette = await getThemePalette();
+const siteConfig = await getSiteConfig();
+const palette = siteConfig.theme.palette;
+const htmlLang = getHtmlLang(siteConfig);
 ---
 
-<html lang="zh-CN" data-palette={palette}>
+<html lang={htmlLang} data-palette={palette}>
   <head>
     <BaseHead title={title} description={description} />
     <style>

--- a/src/pages/blog/categories/[category].astro
+++ b/src/pages/blog/categories/[category].astro
@@ -8,6 +8,7 @@ import BlogTopNav from '../../../components/blog/BlogTopNav.astro';
 import { getSiteConfig } from '../../../data/site';
 import { getAllCategories, getPostsByCategory } from '../../../utils/content-groups';
 import { sortBlogPostsForArchive } from '../../../utils/content-dates';
+import { getUiText } from '../../../utils/ui-text';
 
 export async function getStaticPaths() {
   const posts = await getCollection('blog', ({ data }) => !data.draft);
@@ -34,10 +35,12 @@ export async function getStaticPaths() {
   });
 }
 
-const { site, theme, pages } = await getSiteConfig();
+const siteConfig = await getSiteConfig();
+const { site, theme, pages } = siteConfig;
 const palette = theme.palette;
 const pageMeta = pages.blog;
 const { category, page } = Astro.props;
+const ui = getUiText(siteConfig);
 ---
 
 <!doctype html>
@@ -61,12 +64,12 @@ const { category, page } = Astro.props;
   <body>
     <BlogTopNav />
     <main data-pagefind-body>
-      <BackLink href="/blog/categories/" label="Back" />
+      <BackLink href="/blog/categories/" label={ui.groups.back} />
       <BlogArchive
         page={page}
-        headerKicker="Category"
+        headerKicker={ui.groups.category}
         headerTitle={category.name}
-        headerNote={`${category.count} ${category.count === 1 ? 'article' : 'articles'} in this topic.`}
+        headerNote={ui.groups.categoryNote(category.count)}
         coverImageStyle={pageMeta.coverImageStyle}
       />
     </main>

--- a/src/pages/blog/categories/[category].astro
+++ b/src/pages/blog/categories/[category].astro
@@ -44,7 +44,7 @@ const ui = getUiText(siteConfig);
 ---
 
 <!doctype html>
-<html lang="zh-CN" data-palette={palette}>
+<html lang={ui.locale} data-palette={palette}>
   <head>
     <BaseHead title={`${category.name} | ${site.title}`} description={site.description} />
     <style>

--- a/src/pages/blog/categories/index.astro
+++ b/src/pages/blog/categories/index.astro
@@ -7,11 +7,14 @@ import BlogTopNav from '../../../components/blog/BlogTopNav.astro';
 import CategoryCard from '../../../components/blog/CategoryCard.astro';
 import { getSiteConfig } from '../../../data/site';
 import { getAllCategories } from '../../../utils/content-groups';
+import { getUiText } from '../../../utils/ui-text';
 
-const { site, theme, pages } = await getSiteConfig();
+const siteConfig = await getSiteConfig();
+const { site, theme, pages } = siteConfig;
 const palette = theme.palette;
 const pageMeta = pages.blog.categories;
 const categories = getAllCategories(await getCollection('blog', ({ data }) => !data.draft));
+const ui = getUiText(siteConfig);
 ---
 
 <!doctype html>
@@ -60,7 +63,7 @@ const categories = getAllCategories(await getCollection('blog', ({ data }) => !d
   <body>
     <BlogTopNav />
     <main data-pagefind-body>
-      <BackLink href="/blog/" label="Back" />
+      <BackLink href="/blog/" label={ui.groups.back} />
       <header class="archive-hero archive-header-shared page-header-spacing">
         <div class="archive-header-main">
           <p class="archive-kicker">{pageMeta.kicker}</p>
@@ -74,13 +77,13 @@ const categories = getAllCategories(await getCollection('blog', ({ data }) => !d
 
       {
         categories.length > 0 ? (
-          <section class="category-grid" aria-label="Blog categories">
+          <section class="category-grid" aria-label={ui.groups.categories}>
             {categories.map((category) => (
               <CategoryCard name={category.name} slug={category.slug} count={category.count} />
             ))}
           </section>
         ) : (
-          <p class="empty-note">No categories have been added yet.</p>
+          <p class="empty-note">{ui.groups.emptyCategories}</p>
         )
       }
     </main>

--- a/src/pages/blog/categories/index.astro
+++ b/src/pages/blog/categories/index.astro
@@ -18,7 +18,7 @@ const ui = getUiText(siteConfig);
 ---
 
 <!doctype html>
-<html lang="zh-CN" data-palette={palette}>
+<html lang={ui.locale} data-palette={palette}>
   <head>
     <BaseHead title={`${pageMeta.title} | ${site.title}`} description={pageMeta.note} />
     <style>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -7,9 +7,12 @@ import BlogArchive from '../../components/blog/BlogArchive.astro';
 import GroupNav from '../../components/blog/GroupNav.astro';
 import { getSiteConfig } from '../../data/site';
 import { sortBlogPostsForArchive } from '../../utils/content-dates';
+import { getHtmlLang } from '../../utils/ui-text';
 
-const { site, theme, pages } = await getSiteConfig();
+const siteConfig = await getSiteConfig();
+const { site, theme, pages } = siteConfig;
 const palette = theme.palette;
+const htmlLang = getHtmlLang(siteConfig);
 const pageMeta = pages.blog;
 const posts = sortBlogPostsForArchive(await getCollection('blog', ({ data }) => !data.draft));
 const postsPerPage = pageMeta.postsPerPage;
@@ -28,7 +31,7 @@ const page = {
 ---
 
 <!doctype html>
-<html lang="zh-CN" data-palette={palette}>
+<html lang={htmlLang} data-palette={palette}>
   <head>
     <BaseHead title={`${pageMeta.title} | ${site.title}`} description={pageMeta.subtitle} />
     <style>

--- a/src/pages/blog/page/[page].astro
+++ b/src/pages/blog/page/[page].astro
@@ -6,6 +6,7 @@ import BlogArchive from '../../../components/blog/BlogArchive.astro';
 import BlogTopNav from '../../../components/blog/BlogTopNav.astro';
 import { getSiteConfig } from '../../../data/site';
 import { sortBlogPostsForArchive } from '../../../utils/content-dates';
+import { getHtmlLang } from '../../../utils/ui-text';
 
 export async function getStaticPaths() {
   const { pages } = await getSiteConfig();
@@ -39,14 +40,16 @@ export async function getStaticPaths() {
   });
 }
 
-const { site, theme, pages } = await getSiteConfig();
+const siteConfig = await getSiteConfig();
+const { site, theme, pages } = siteConfig;
 const palette = theme.palette;
+const htmlLang = getHtmlLang(siteConfig);
 const pageMeta = pages.blog;
 const { page, postOffset } = Astro.props;
 ---
 
 <!doctype html>
-<html lang="zh-CN" data-palette={palette}>
+<html lang={htmlLang} data-palette={palette}>
   <head>
     <BaseHead
       title={`${pageMeta.title} | Page ${page.currentPage} | ${site.title}`}

--- a/src/pages/blog/series/[series].astro
+++ b/src/pages/blog/series/[series].astro
@@ -8,6 +8,7 @@ import FormattedDate from '../../../components/FormattedDate.astro';
 import SeriesProgress from '../../../components/blog/SeriesProgress.astro';
 import { getSiteConfig } from '../../../data/site';
 import { getAllSeries, getPostsBySeries } from '../../../utils/content-groups';
+import { getUiText } from '../../../utils/ui-text';
 
 export async function getStaticPaths() {
   const posts = await getCollection('blog', ({ data }) => !data.draft);
@@ -21,10 +22,12 @@ export async function getStaticPaths() {
   }));
 }
 
-const { site, theme } = await getSiteConfig();
+const siteConfig = await getSiteConfig();
+const { site, theme } = siteConfig;
 const palette = theme.palette;
 const { series, posts } = Astro.props;
 const basePath = import.meta.env.BASE_URL.replace(/\/$/, '');
+const ui = getUiText(siteConfig);
 ---
 
 <!doctype html>
@@ -114,19 +117,16 @@ const basePath = import.meta.env.BASE_URL.replace(/\/$/, '');
   <body>
     <BlogTopNav />
     <main data-pagefind-body>
-      <BackLink href="/blog/series/" label="Back" />
+      <BackLink href="/blog/series/" label={ui.groups.back} />
       <header class="archive-hero archive-header-shared page-header-spacing">
         <div class="archive-header-main series-detail-header">
           <div>
-            <p class="archive-kicker">Series</p>
+            <p class="archive-kicker">{ui.groups.series}</p>
             <h1 class="archive-title">{series.name}</h1>
           </div>
           <SeriesProgress current={posts.length} total={posts.length} />
         </div>
-        <p class="archive-note">
-          {posts.length}
-          {posts.length === 1 ? 'article' : 'articles'} in reading order.
-        </p>
+        <p class="archive-note">{ui.groups.seriesNote(posts.length)}</p>
       </header>
 
       <ol class="series-stack">

--- a/src/pages/blog/series/[series].astro
+++ b/src/pages/blog/series/[series].astro
@@ -31,7 +31,7 @@ const ui = getUiText(siteConfig);
 ---
 
 <!doctype html>
-<html lang="zh-CN" data-palette={palette}>
+<html lang={ui.locale} data-palette={palette}>
   <head>
     <BaseHead title={`${series.name} | ${site.title}`} description={site.description} />
     <style>

--- a/src/pages/blog/series/index.astro
+++ b/src/pages/blog/series/index.astro
@@ -7,11 +7,14 @@ import BlogTopNav from '../../../components/blog/BlogTopNav.astro';
 import SeriesCard from '../../../components/blog/SeriesCard.astro';
 import { getSiteConfig } from '../../../data/site';
 import { getAllSeries } from '../../../utils/content-groups';
+import { getUiText } from '../../../utils/ui-text';
 
-const { site, theme, pages } = await getSiteConfig();
+const siteConfig = await getSiteConfig();
+const { site, theme, pages } = siteConfig;
 const palette = theme.palette;
 const pageMeta = pages.blog.series;
 const series = getAllSeries(await getCollection('blog', ({ data }) => !data.draft));
+const ui = getUiText(siteConfig);
 ---
 
 <!doctype html>
@@ -49,7 +52,7 @@ const series = getAllSeries(await getCollection('blog', ({ data }) => !data.draf
   <body>
     <BlogTopNav />
     <main data-pagefind-body>
-      <BackLink href="/blog/" label="Back" />
+      <BackLink href="/blog/" label={ui.groups.back} />
       <header class="archive-hero archive-header-shared page-header-spacing">
         <div class="archive-header-main">
           <p class="archive-kicker">{pageMeta.kicker}</p>
@@ -63,13 +66,13 @@ const series = getAllSeries(await getCollection('blog', ({ data }) => !data.draf
 
       {
         series.length > 0 ? (
-          <section class="series-list" aria-label="Blog series">
+          <section class="series-list" aria-label={ui.groups.series}>
             {series.map((item) => (
               <SeriesCard name={item.name} slug={item.slug} posts={item.posts} />
             ))}
           </section>
         ) : (
-          <p class="empty-note">No series have been added yet.</p>
+          <p class="empty-note">{ui.groups.emptySeries}</p>
         )
       }
     </main>

--- a/src/pages/blog/series/index.astro
+++ b/src/pages/blog/series/index.astro
@@ -18,7 +18,7 @@ const ui = getUiText(siteConfig);
 ---
 
 <!doctype html>
-<html lang="zh-CN" data-palette={palette}>
+<html lang={ui.locale} data-palette={palette}>
   <head>
     <BaseHead title={`${pageMeta.title} | ${site.title}`} description={pageMeta.note} />
     <style>

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -8,6 +8,7 @@ import BlogTopNav from '../../components/blog/BlogTopNav.astro';
 import { getSiteConfig } from '../../data/site';
 import { sortBlogPostsForArchive } from '../../utils/content-dates';
 import { getAllTags } from '../../utils/content-groups';
+import { getUiText } from '../../utils/ui-text';
 
 export async function getStaticPaths() {
   const posts = await getCollection('blog', ({ data }) => !data.draft);
@@ -34,10 +35,12 @@ export async function getStaticPaths() {
   });
 }
 
-const { site, theme, pages } = await getSiteConfig();
+const siteConfig = await getSiteConfig();
+const { site, theme, pages } = siteConfig;
 const palette = theme.palette;
 const pageMeta = pages.blog;
 const { tag, page } = Astro.props;
+const ui = getUiText(siteConfig);
 ---
 
 <!doctype html>
@@ -61,12 +64,12 @@ const { tag, page } = Astro.props;
   <body>
     <BlogTopNav />
     <main data-pagefind-body>
-      <BackLink href="/blog/" label="Back" />
+      <BackLink href="/blog/" label={ui.groups.back} />
       <BlogArchive
         page={page}
-        headerKicker="Tag"
+        headerKicker={ui.groups.tag}
         headerTitle={tag.name}
-        headerNote={`${tag.count} ${tag.count === 1 ? 'article' : 'articles'} with this tag.`}
+        headerNote={ui.groups.tagNote(tag.count)}
         coverImageStyle={pageMeta.coverImageStyle}
       />
     </main>

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -44,7 +44,7 @@ const ui = getUiText(siteConfig);
 ---
 
 <!doctype html>
-<html lang="zh-CN" data-palette={palette}>
+<html lang={ui.locale} data-palette={palette}>
   <head>
     <BaseHead title={`${tag.name} | ${site.title}`} description={site.description} />
     <style>

--- a/src/pages/vibe.astro
+++ b/src/pages/vibe.astro
@@ -7,10 +7,13 @@ import SmartImage from '../components/SmartImage.astro';
 import BlogTopNav from '../components/blog/BlogTopNav.astro';
 import ZoomableImage from '../components/mdx/ZoomableImage.astro';
 import { getSiteConfig } from '../data/site';
+import { getHtmlLang } from '../utils/ui-text';
 import { getVibeImageLayout } from '../utils/vibe-image-layout';
 
-const { site, theme, pages } = await getSiteConfig();
+const siteConfig = await getSiteConfig();
+const { site, theme, pages } = siteConfig;
 const palette = theme.palette;
+const htmlLang = getHtmlLang(siteConfig);
 const pageMeta = pages.vibe;
 const showTrail = pageMeta.showTrail;
 
@@ -30,7 +33,7 @@ const vibes = await Promise.all(
 ---
 
 <!doctype html>
-<html lang="zh-CN" data-palette={palette}>
+<html lang={htmlLang} data-palette={palette}>
   <head>
     <BaseHead title={`${pageMeta.title} | ${site.title}`} description={pageMeta.subtitle} />
     <style>

--- a/src/utils/site-search.ts
+++ b/src/utils/site-search.ts
@@ -68,15 +68,15 @@ function getResultPath(url: string) {
   }
 }
 
-function getResultKind(url: string) {
+function getResultKind(root: HTMLElement, url: string) {
   const path = getResultPath(url);
 
-  if (/^\/blog\/[^/]+\/?$/.test(path)) return 'Blog note';
-  if (path.startsWith('/blog')) return 'Blog index';
-  if (path.startsWith('/vibe')) return 'Vibe';
-  if (path.startsWith('/projects')) return 'Project';
+  if (/^\/blog\/[^/]+\/?$/.test(path)) return root.dataset.searchKindBlogNote || 'Blog note';
+  if (path.startsWith('/blog')) return root.dataset.searchKindBlogIndex || 'Blog index';
+  if (path.startsWith('/vibe')) return root.dataset.searchKindVibe || 'Vibe';
+  if (path.startsWith('/projects')) return root.dataset.searchKindProject || 'Project';
 
-  return 'Page';
+  return root.dataset.searchKindPage || 'Page';
 }
 
 function getResultTitle(result: Awaited<ReturnType<PagefindResult['data']>>) {
@@ -159,10 +159,10 @@ function renderResults(root: HTMLElement, results: Awaited<ReturnType<PagefindRe
     title.className = 'site-search-result-title';
     title.textContent = getResultTitle(result);
     meta.className = 'site-search-result-meta';
-    meta.textContent = `${getResultKind(result.url)} - ${getResultPath(result.url)}`;
+    meta.textContent = `${getResultKind(root, result.url)} - ${getResultPath(result.url)}`;
     match.className = 'site-search-result-match';
     matchLabel.className = 'site-search-result-match-label';
-    matchLabel.textContent = 'Matched passage';
+    matchLabel.textContent = root.dataset.searchMatchLabel || 'Matched passage';
     excerpt.className = 'site-search-result-excerpt';
     excerpt.innerHTML = result.excerpt;
 

--- a/src/utils/ui-text.ts
+++ b/src/utils/ui-text.ts
@@ -1,0 +1,247 @@
+import type { SiteConfig } from '../data/site';
+import en from '../i18n/en.json';
+import zhCN from '../i18n/zh-CN.json';
+import zhTW from '../i18n/zh-TW.json';
+
+export const defaultUiLanguage = 'en';
+
+const rawUiText = {
+  en,
+  'zh-CN': zhCN,
+  'zh-TW': zhTW,
+} as const;
+
+type TemplateValues = Record<string, string | number>;
+type Message = string | { one?: string; other: string };
+
+type RawUiText = {
+  locale: string;
+  doing: {
+    recently: string;
+  };
+  heatmap: {
+    totalPosts: string;
+    activeDays: string;
+    dayStreak: string;
+    latest: string;
+    latestPublishedPosts: string;
+    openLatestPost: Message;
+    less: string;
+    more: string;
+    weekdays: string[];
+    writingSince: Message;
+    recentWeeks: Message;
+    upcoming: string;
+    postCount: Message;
+  };
+  groups: {
+    categories: string;
+    series: string;
+    category: string;
+    tag: string;
+    back: string;
+    browseByTopic: string;
+    followConnectedNotes: string;
+    blogBrowsingGroups: string;
+    emptyCategories: string;
+    emptySeries: string;
+    articleCount: Message;
+    categoryNote: Message;
+    seriesNote: Message;
+    tagNote: Message;
+    publishedCount: Message;
+    publishedArticles: Message;
+    viewMore: Message;
+  };
+  article: {
+    metadata: string;
+    groups: string;
+    readingTools: string;
+    wordCount: Message;
+    readingTime: Message;
+    moreInSeries: Message;
+    previousInSeries: Message;
+    nextInSeries: Message;
+    pinned: string;
+    moreFromSite: Message;
+  };
+  toc: {
+    title: string;
+    open: string;
+    close: string;
+    expand: string;
+    collapse: string;
+    showAll: string;
+    collapseButton: string;
+  };
+  pagination: {
+    blog: string;
+    previous: string;
+    next: string;
+    page: Message;
+  };
+  search: {
+    title: string;
+    trigger: string;
+    close: string;
+    idle: string;
+    loading: string;
+    empty: string;
+    unavailable: string;
+    resultKinds: {
+      blogNote: string;
+      blogIndex: string;
+      vibe: string;
+      project: string;
+      page: string;
+    };
+    matchedPassage: string;
+  };
+};
+
+export type UiLanguage = keyof typeof rawUiText;
+
+export type UiText = Omit<RawUiText, 'heatmap' | 'groups' | 'article' | 'pagination'> & {
+  heatmap: Omit<
+    RawUiText['heatmap'],
+    'openLatestPost' | 'writingSince' | 'recentWeeks' | 'postCount'
+  > & {
+    openLatestPost: (title: string) => string;
+    writingSince: (date: string) => string;
+    recentWeeks: (weeks: number) => string;
+    postCount: (count: number) => string;
+  };
+  groups: Omit<
+    RawUiText['groups'],
+    | 'articleCount'
+    | 'categoryNote'
+    | 'seriesNote'
+    | 'tagNote'
+    | 'publishedCount'
+    | 'publishedArticles'
+    | 'viewMore'
+  > & {
+    articleCount: (count: number) => string;
+    categoryNote: (count: number) => string;
+    seriesNote: (count: number) => string;
+    tagNote: (count: number) => string;
+    publishedCount: (count: number) => string;
+    publishedArticles: (count: number) => string;
+    viewMore: (count: number) => string;
+  };
+  article: Omit<
+    RawUiText['article'],
+    | 'wordCount'
+    | 'readingTime'
+    | 'moreInSeries'
+    | 'previousInSeries'
+    | 'nextInSeries'
+    | 'moreFromSite'
+  > & {
+    wordCount: (count: number) => string;
+    readingTime: (minutes: number) => string;
+    moreInSeries: (name: string) => string;
+    previousInSeries: (name: string) => string;
+    nextInSeries: (name: string) => string;
+    moreFromSite: (siteTitle: string) => string;
+  };
+  pagination: Omit<RawUiText['pagination'], 'page'> & {
+    page: (current: number, total: number) => string;
+  };
+};
+
+function formatMessage(message: Message, values: TemplateValues = {}) {
+  const template =
+    typeof message === 'string'
+      ? message
+      : Number(values.count) === 1 && message.one
+        ? message.one
+        : message.other;
+
+  return template.replace(/\{(\w+)\}/g, (_, key: string) => String(values[key] ?? ''));
+}
+
+function formatNumber(value: number, locale: string) {
+  return value.toLocaleString(locale);
+}
+
+function createUiText(raw: RawUiText): UiText {
+  return {
+    locale: raw.locale,
+    doing: raw.doing,
+    heatmap: {
+      ...raw.heatmap,
+      openLatestPost: (title) => formatMessage(raw.heatmap.openLatestPost, { title }),
+      writingSince: (date) => formatMessage(raw.heatmap.writingSince, { date }),
+      recentWeeks: (weeks) => formatMessage(raw.heatmap.recentWeeks, { weeks }),
+      postCount: (count) => formatMessage(raw.heatmap.postCount, { count }),
+    },
+    groups: {
+      ...raw.groups,
+      articleCount: (count) => formatMessage(raw.groups.articleCount, { count }),
+      categoryNote: (count) => formatMessage(raw.groups.categoryNote, { count }),
+      seriesNote: (count) => formatMessage(raw.groups.seriesNote, { count }),
+      tagNote: (count) => formatMessage(raw.groups.tagNote, { count }),
+      publishedCount: (count) => formatMessage(raw.groups.publishedCount, { count }),
+      publishedArticles: (count) => formatMessage(raw.groups.publishedArticles, { count }),
+      viewMore: (count) => formatMessage(raw.groups.viewMore, { count }),
+    },
+    article: {
+      ...raw.article,
+      wordCount: (count) =>
+        formatMessage(raw.article.wordCount, {
+          count: formatNumber(count, raw.locale),
+        }),
+      readingTime: (minutes) => formatMessage(raw.article.readingTime, { minutes }),
+      moreInSeries: (name) => formatMessage(raw.article.moreInSeries, { name }),
+      previousInSeries: (name) => formatMessage(raw.article.previousInSeries, { name }),
+      nextInSeries: (name) => formatMessage(raw.article.nextInSeries, { name }),
+      moreFromSite: (siteTitle) => formatMessage(raw.article.moreFromSite, { siteTitle }),
+    },
+    toc: raw.toc,
+    pagination: {
+      ...raw.pagination,
+      page: (current, total) => formatMessage(raw.pagination.page, { current, total }),
+    },
+    search: raw.search,
+  };
+}
+
+const uiText = Object.fromEntries(
+  Object.entries(rawUiText).map(([language, text]) => [language, createUiText(text)]),
+) as Record<UiLanguage, UiText>;
+
+export function normalizeUiLanguage(value: string | undefined): UiLanguage {
+  const language = value?.trim().toLowerCase();
+
+  if (!language) return defaultUiLanguage;
+
+  const aliases: Record<string, UiLanguage> = {
+    en: 'en',
+    'en-us': 'en',
+    en_us: 'en',
+    'zh-cn': 'zh-CN',
+    'zh-hans': 'zh-CN',
+    zh_cn: 'zh-CN',
+    zh_hans: 'zh-CN',
+    cn: 'zh-CN',
+    'zh-tw': 'zh-TW',
+    'zh-hant': 'zh-TW',
+    'zh-hk': 'zh-TW',
+    'zh-mo': 'zh-TW',
+    zh_tw: 'zh-TW',
+    zh_hant: 'zh-TW',
+    zh_hk: 'zh-TW',
+    zh_mo: 'zh-TW',
+  };
+
+  return aliases[language] ?? defaultUiLanguage;
+}
+
+export function getUiLanguage(config: SiteConfig): UiLanguage {
+  return normalizeUiLanguage(config.theme.lang);
+}
+
+export function getUiText(config: SiteConfig): UiText {
+  return uiText[getUiLanguage(config)];
+}

--- a/src/utils/ui-text.ts
+++ b/src/utils/ui-text.ts
@@ -220,9 +220,14 @@ export function normalizeUiLanguage(value: string | undefined): UiLanguage {
     en: 'en',
     'en-us': 'en',
     en_us: 'en',
+    zh: 'zh-CN',
     'zh-cn': 'zh-CN',
+    'zh-sg': 'zh-CN',
+    'zh-my': 'zh-CN',
     'zh-hans': 'zh-CN',
     zh_cn: 'zh-CN',
+    zh_sg: 'zh-CN',
+    zh_my: 'zh-CN',
     zh_hans: 'zh-CN',
     cn: 'zh-CN',
     'zh-tw': 'zh-TW',
@@ -244,4 +249,8 @@ export function getUiLanguage(config: SiteConfig): UiLanguage {
 
 export function getUiText(config: SiteConfig): UiText {
   return uiText[getUiLanguage(config)];
+}
+
+export function getHtmlLang(config: SiteConfig): UiText['locale'] {
+  return getUiText(config).locale;
 }


### PR DESCRIPTION
## Summary

- Add configurable native blog UI language via `config.theme.lang`
- Support `en`, `zh-CN`, and `zh-TW` with alias fallback to English
- Move UI strings into `src/i18n/*.json` and keep runtime formatting in `ui-text.ts`
- Localize blog widgets, archive metadata, TOC, pagination, search labels, and group labels
- Prune unused `site.toml` fields and update related schemas/components
- Include i18n JSON in UI font subsetting so Chinese UI strings use the lightweight subset
- Update docs for site config and font subsetting behavior

## Validation

- `bun run format:check`
- `bunx tsc --noEmit`
- `bun run build`
- `NAVFOLIO_CONTENT_SOURCE=docs; bun run build`