### PR TITLE
chore: refine blog archive layout

### DIFF
--- a/src/components/blog/BlogArchive.astro
+++ b/src/components/blog/BlogArchive.astro
@@ -525,7 +525,6 @@ function getPageHref(pageNumber: number) {
 
   .post-excerpt {
     display: -webkit-box;
-    max-height: calc(1.78em * 2);
     overflow: hidden;
     margin: 0;
     color: var(--paper-ink-soft);

--- a/src/components/blog/BlogArchive.astro
+++ b/src/components/blog/BlogArchive.astro
@@ -305,6 +305,10 @@ function getPageHref(pageNumber: number) {
     width: min(64%, 720px);
   }
 
+  .post-link.without-thumb .post-copy {
+    width: 100%;
+  }
+
   .post-copy {
     position: relative;
     z-index: 1;
@@ -520,10 +524,16 @@ function getPageHref(pageNumber: number) {
   }
 
   .post-excerpt {
+    display: -webkit-box;
+    max-height: calc(1.78em * 2);
+    overflow: hidden;
     margin: 0;
     color: var(--paper-ink-soft);
     font-size: 0.98rem;
     line-height: 1.78;
+    text-overflow: ellipsis;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
   }
 
   .thumb-wrap {

--- a/src/components/blog/TocTree.astro
+++ b/src/components/blog/TocTree.astro
@@ -154,8 +154,7 @@ const { items, level = 1, path = '', idPrefix = 'toc', navLink = false } = Astro
 
   .toc-card .toc-tree a,
   .mobile-toc-panel .toc-tree a {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr);
+    display: flex;
     align-items: center;
     min-width: 0;
     min-height: 36px;
@@ -227,7 +226,6 @@ const { items, level = 1, path = '', idPrefix = 'toc', navLink = false } = Astro
 
     .toc-card .toc-tree a,
     .mobile-toc-panel .toc-tree a {
-      grid-template-columns: minmax(0, 1fr);
       min-height: 38px;
       padding: 8px;
       font-size: 0.82rem;

--- a/src/components/blog/TocTree.astro
+++ b/src/components/blog/TocTree.astro
@@ -20,7 +20,6 @@ const { items, level = 1, path = '', idPrefix = 'toc', navLink = false } = Astro
       const normalizedHref = normalizeHash(item.href) || item.href;
       const branchKey = path ? `${path}-${index + 1}` : `${index + 1}`;
       const branchId = `${idPrefix}-${branchKey}-children`;
-      const numberLabel = branchKey.replace(/-/g, '.');
       const hasChildren = item.children.length > 0;
 
       return (
@@ -49,7 +48,6 @@ const { items, level = 1, path = '', idPrefix = 'toc', navLink = false } = Astro
               data-toc-link
               data-toc-hash={normalizedHref}
             >
-              <span>{numberLabel}</span>
               {item.label}
             </a>
           </div>
@@ -157,8 +155,7 @@ const { items, level = 1, path = '', idPrefix = 'toc', navLink = false } = Astro
   .toc-card .toc-tree a,
   .mobile-toc-panel .toc-tree a {
     display: grid;
-    grid-template-columns: 28px minmax(0, 1fr);
-    gap: 8px;
+    grid-template-columns: minmax(0, 1fr);
     align-items: center;
     min-width: 0;
     min-height: 36px;
@@ -177,14 +174,6 @@ const { items, level = 1, path = '', idPrefix = 'toc', navLink = false } = Astro
 
   .toc-card[data-font='article'] .toc-tree a {
     font-family: var(--font-article);
-  }
-
-  .toc-card .toc-tree a > span,
-  .mobile-toc-panel .toc-tree a > span {
-    color: var(--paper-ink-faint);
-    font-family: var(--font-ui-label);
-    font-size: 0.7rem;
-    font-weight: 700;
   }
 
   .toc-card .toc-tree a[data-state='past'],
@@ -238,7 +227,7 @@ const { items, level = 1, path = '', idPrefix = 'toc', navLink = false } = Astro
 
     .toc-card .toc-tree a,
     .mobile-toc-panel .toc-tree a {
-      grid-template-columns: 24px minmax(0, 1fr);
+      grid-template-columns: minmax(0, 1fr);
       min-height: 38px;
       padding: 8px;
       font-size: 0.82rem;


### PR DESCRIPTION
## Summary

- Remove numeric labels from article table-of-contents entries.
- Let archive cards without `heroImage` use the full text width instead of reserving image layout space.
- Clamp long archive excerpts to two lines with an ellipsis to prevent clipped half-lines.

## Validation

- `bun run build`
- Commit hook ran `bun run format:check` and build successfully.

## Notes

`src/docs` has an existing submodule pointer change in the working tree, but it is not included in this PR.