### PR TITLE
Fix/about comments

### DIFF
--- a/docs/superpowers/plans/2026-07-13-about-comments.md
+++ b/docs/superpowers/plans/2026-07-13-about-comments.md
@@ -1,0 +1,127 @@
+# About Page Comments Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make About pages honor their `comments` frontmatter while preserving existing blog and project behavior.
+
+**Architecture:** Add a small pure predicate to the existing comments utility that declares which content collections can mount `CommentSection`. Use the predicate in `BlogArticle` so both `blog` and `about` enter the existing comment configuration pipeline, while other collections remain unchanged.
+
+**Tech Stack:** Astro 7, TypeScript 6, Bun test runner, Astro Content Collections
+
+## Global Constraints
+
+- About supports both `src/content/about.md` and `src/content/about.mdx` through the existing collection loader.
+- `comments: false` continues to suppress comments through `CommentSection`.
+- Projects and other non-blog/non-about collections must not gain comments.
+- Do not modify content in the `src/docs` sub-repository.
+
+---
+
+### Task 1: Support About in the comment mount decision
+
+**Files:**
+
+- Create: `src/utils/comments.test.ts`
+- Modify: `src/utils/comments.ts`
+- Modify: `src/layouts/BlogArticle.astro`
+
+**Interfaces:**
+
+- Consumes: `post.collection?: string` from the existing `BlogArticle` post contract.
+- Produces: `supportsCommentSection(collection?: string): boolean` for layout-level comment mounting.
+
+- [x] **Step 1: Write the failing predicate tests**
+
+Create `src/utils/comments.test.ts`:
+
+```ts
+import { describe, expect, test } from 'bun:test';
+import { supportsCommentSection } from './comments';
+
+describe('supportsCommentSection', () => {
+  test('supports blog and about content collections', () => {
+    expect(supportsCommentSection('blog')).toBe(true);
+    expect(supportsCommentSection('about')).toBe(true);
+  });
+
+  test('does not enable comments for other or missing collections', () => {
+    expect(supportsCommentSection('projects')).toBe(false);
+    expect(supportsCommentSection(undefined)).toBe(false);
+  });
+});
+```
+
+- [x] **Step 2: Run the focused test and verify RED**
+
+Run: `bun test src/utils/comments.test.ts`
+
+Expected: FAIL because `supportsCommentSection` is not exported from `src/utils/comments.ts`.
+
+- [x] **Step 3: Implement the minimal predicate**
+
+Add to `src/utils/comments.ts`:
+
+```ts
+const commentSectionCollections = new Set(['blog', 'about']);
+
+export function supportsCommentSection(collection?: string) {
+  return collection ? commentSectionCollections.has(collection) : false;
+}
+```
+
+- [x] **Step 4: Use the predicate in the shared article layout**
+
+Update the comments import in `src/layouts/BlogArticle.astro`:
+
+```ts
+import { resolveCommentsConfig, supportsCommentSection } from '../utils/comments';
+```
+
+Define the mount decision after `isBlogPost`:
+
+```ts
+const shouldMountCommentSection = supportsCommentSection(post.collection);
+```
+
+Replace the blog-only render condition with:
+
+```astro
+{
+  shouldMountCommentSection && (
+    <CommentSection frontmatter={post.data} pathname={Astro.url.pathname} />
+  )
+}
+```
+
+- [x] **Step 5: Run the focused test and verify GREEN**
+
+Run: `bun test src/utils/comments.test.ts`
+
+Expected: 2 passing tests and 0 failures.
+
+- [x] **Step 6: Run regression and static verification**
+
+Run: `bun test`
+
+Expected: all tests pass.
+
+Run: `bun run format:check`
+
+Expected: ESLint and Prettier complete with exit code 0.
+
+Run an Astro build with complete temporary giscus environment values and an About fixture whose frontmatter has `comments: true`, then inspect `dist/about/index.html`.
+
+Expected: build exits 0; About output contains `comment-section` and `data-comment-provider=\"giscus\"`. Restoring `comments: false` and rebuilding must remove the comment section.
+
+- [x] **Step 7: Review and commit**
+
+Run: `git diff --check && git status --short`
+
+Expected: only the test, utility, layout, and plan files are changed; no whitespace errors.
+
+Commit:
+
+```bash
+git add src/utils/comments.test.ts src/utils/comments.ts src/layouts/BlogArticle.astro docs/superpowers/plans/2026-07-13-about-comments.md
+git commit -m "fix: render comments on about pages"
+```

--- a/docs/superpowers/specs/2026-07-13-about-comments-design.md
+++ b/docs/superpowers/specs/2026-07-13-about-comments-design.md
@@ -1,0 +1,28 @@
+# About 页面评论渲染修复设计
+
+## 背景
+
+About 页面从 `src/content/about.md` 或 `src/content/about.mdx` 加载内容，并与博客文章共用 `BlogArticle` 布局。内容 schema 已支持 `comments` 元信息，但布局目前只在内容集合为 `blog` 时挂载 `CommentSection`，导致 About 的 `comments` 配置没有进入现有评论判断链路。
+
+## 目标
+
+- About 页面在 `comments: true`（或使用 schema 默认值）时遵循站点评论配置。
+- About 页面在 `comments: false` 时不渲染评论。
+- 保持博客文章现有行为不变。
+- 不改变 Projects 等其他复用 `BlogArticle` 的页面行为。
+
+## 方案
+
+在评论工具模块中定义支持评论的内容集合判断，仅允许 `blog` 与 `about`。`BlogArticle` 使用该判断决定是否挂载 `CommentSection`；挂载后仍由 `CommentSection` 处理页面元信息、全局开关、provider 配置完整性等现有规则。
+
+数据流为：内容 frontmatter → Content Collection schema → `BlogArticle` → 支持集合判断 → `CommentSection` → 评论 provider。
+
+## 测试
+
+先添加失败测试，证明 `about` 应支持评论而 `projects` 不应被意外开启；再实现最小判断并让测试通过。最后运行相关单元测试、格式检查与带完整评论环境变量的 Astro 构建，并检查 `/about` 构建产物。
+
+## 非目标
+
+- 不调整评论 provider 配置模型。
+- 不为 Projects 页面启用评论。
+- 不修改 `src/docs` 子仓库中的内容。

--- a/src/layouts/BlogArticle.astro
+++ b/src/layouts/BlogArticle.astro
@@ -10,7 +10,7 @@ import CommentSection from '../components/comments/CommentSection.astro';
 import MermaidRenderer from '../components/mdx/MermaidRenderer.astro';
 import ZoomableImage from '../components/mdx/ZoomableImage.astro';
 import { getThemePalette, getSiteConfig } from '../data/site';
-import { resolveCommentsConfig } from '../utils/comments';
+import { resolveCommentsConfig, supportsCommentSection } from '../utils/comments';
 import { sortByDateDesc } from '../utils/content-dates';
 import { getSeriesContext, slugifyGroupName } from '../utils/content-groups';
 import { buildTocTree, countTocItems } from '../utils/toc-tree';
@@ -84,6 +84,7 @@ const post = props.post ?? {
   },
 };
 const isBlogPost = post.collection === 'blog';
+const shouldMountCommentSection = supportsCommentSection(post.collection);
 const { title, description, date, heroImage, showHeroImage = true } = post.data;
 const contentFont = props.contentFont ?? 'article';
 const bodyText = 'body' in post && typeof post.body === 'string' ? post.body : description;
@@ -214,7 +215,11 @@ const hasSidebar = shouldRenderSidebar && hasToc;
           }
         </article>
         {hasRelatedPosts && <RelatedPosts posts={relatedPosts} class="article-after-related" />}
-        {isBlogPost && <CommentSection frontmatter={post.data} pathname={Astro.url.pathname} />}
+        {
+          shouldMountCommentSection && (
+            <CommentSection frontmatter={post.data} pathname={Astro.url.pathname} />
+          )
+        }
       </div>
 
       {

--- a/src/utils/comments.test.ts
+++ b/src/utils/comments.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from 'bun:test';
+import { supportsCommentSection } from './comments';
+
+describe('supportsCommentSection', () => {
+  test('supports blog and about content collections', () => {
+    expect(supportsCommentSection('blog')).toBe(true);
+    expect(supportsCommentSection('about')).toBe(true);
+  });
+
+  test('does not enable comments for other or missing collections', () => {
+    expect(supportsCommentSection('projects')).toBe(false);
+    expect(supportsCommentSection(undefined)).toBe(false);
+  });
+});

--- a/src/utils/comments.ts
+++ b/src/utils/comments.ts
@@ -5,6 +5,11 @@ export type CommentsConfig = SiteConfig['comments'];
 
 const giscusRequiredFields = ['repo', 'repo_id', 'category', 'category_id'] as const;
 const commentProviders = ['giscus', 'utterances', 'waline', 'none'] as const;
+const commentSectionCollections = new Set(['blog', 'about']);
+
+export function supportsCommentSection(collection?: string) {
+  return collection ? commentSectionCollections.has(collection) : false;
+}
 
 function envValue(key: string) {
   return import.meta.env[key]?.trim() ?? '';


### PR DESCRIPTION
## 变更说明

修复 About 页面无法根据 Frontmatter 配置渲染评论区的问题。

### 问题原因

About 内容集合已经支持 `comments` 元信息，但共用的 `BlogArticle` 布局仅在内容属于 `blog` 集合时挂载 `CommentSection`。

因此，即使 `src/content/about.md` 或 `src/content/about.mdx` 设置了 `comments: true`，该配置也不会进入评论渲染流程。

### 本次修改

- 允许 `blog` 和 `about` 内容集合挂载评论区。
- 继续使用现有的全局评论开关和 Provider 配置。
- `comments: true` 或省略该字段时，About 页面遵循全局评论配置。
- `comments: false` 时不渲染评论区。
- Projects 等其他内容集合保持现有行为，不会意外启用评论。
- 添加集合判断的回归测试。
- 补充设计文档和实施计划。

### 验证结果

- `bun test`：18 项测试通过，0 项失败。
- `bun run format:check`：通过。
- 提交钩子的 Astro 完整构建及 Pagefind 索引构建通过。
- 使用完整的临时 giscus 配置验证 About 页面：
  - `comments: true` 时正确生成 giscus 评论区。
  - `comments: false` 时不生成评论区。