### PR TITLE
fix: improve friend circle sync, RSS categories, and local docs builds

### DIFF
--- a/.github/deepseek-reviewer.json
+++ b/.github/deepseek-reviewer.json
@@ -3,21 +3,21 @@
   "reviewLanguage": "zh-CN",
   "model": "deepseek-v4-flash",
   "baseUrl": "https://api.deepseek.com",
-  "temperature": 0.1,
+  "temperature": 0,
   "maxOutputTokens": 1800,
   "requestTimeoutMs": 90000,
   "maxRetries": 3,
-  "minSeverity": "low",
-  "minConfidence": 0.5,
-  "maxComments": 12,
-  "maxCommentsPerFile": 6,
-  "maxHunks": 60,
+  "minSeverity": "medium",
+  "minConfidence": 0.75,
+  "maxComments": 8,
+  "maxCommentsPerFile": 3,
+  "maxHunks": 50,
   "maxHunkLines": 140,
   "hunkContextLines": 4,
   "maxHunkChars": 9000,
   "maxPromptCharsPerRequest": 26000,
   "maxDiffCharsTotal": 90000,
-  "postNoIssuesComment": true,
+  "postNoIssuesComment": false,
   "includeSuggestionText": true,
   "ignorePatterns": [
     "**/node_modules/**",
@@ -44,6 +44,7 @@
     "API misuse",
     "high-impact performance problems",
     "missing validation for user-controlled input",
+    "cross-platform compatibility for local tooling and CI",
     "Astro lifecycle issues, especially duplicate event listeners after astro:page-load or view transitions",
     "DOM event listener cleanup and repeated initialization bugs",
     "client-side memory leaks caused by repeated page navigation"
@@ -53,6 +54,7 @@
     "subjective style preferences",
     "renaming suggestions unless there is a real bug",
     "comments that only say code is good",
-    "issues not visible from this diff"
+    "issues not visible from this diff",
+    "possible issues without a concrete failure path in the changed code"
   ]
 }

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -48,6 +48,10 @@ jobs:
           input: ${{ vars.NAVFOLIO_FRIEND_LINKS_SRC }}
           output: public/friend-circle.json
           max-posts-per-feed: '12'
+          name-field: ${{ vars.NAVFOLIO_FRIEND_LINKS_NAME_FIELD || 'name' }}
+          url-field: ${{ vars.NAVFOLIO_FRIEND_LINKS_URL_FIELD || 'url' }}
+          avatar-field: ${{ vars.NAVFOLIO_FRIEND_LINKS_AVATAR_FIELD || 'avatar' }}
+          rss-field: ${{ vars.NAVFOLIO_FRIEND_LINKS_RSS_FIELD || 'rss' }}
 
       - name: Build site
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dist/
 
 # dependencies
 node_modules/
+.venv/
 
 # logs
 npm-debug.log*

--- a/AGENT.md
+++ b/AGENT.md
@@ -3,6 +3,12 @@
 This repository is preparing the Navfolio v1 refactor. Future AI coding work
 should use `.agents/` as the coordination directory.
 
+When this repository is opened from the Navfolio multi-repository workspace,
+also read `../AGENT.md` and `../.agents/README.md`. They define the dependency,
+documentation-submodule, delivery, and PR-review rules that apply across the
+official plugin and page repositories. These local instructions add the v1
+refactor-specific constraints below.
+
 ## Start Here
 
 1. Read `.agents/README.md`.

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@expressive-code/plugin-collapsible-sections": "^0.44.0",
         "@expressive-code/plugin-line-numbers": "^0.44.0",
         "@fontsource/maple-mono": "^5.2.6",
-        "@navfolio/mdx-components": "github:navfolio/mdx-components#0857ec2",
+        "@navfolio/mdx-components": "github:navfolio/mdx-components#dd9fabf",
         "@navfolio/pages": "github:navfolio/pages",
         "@navfolio/plugin-markdown": "github:navfolio/plugin-markdown",
         "@tailwindcss/vite": "^4.3.2",
@@ -280,7 +280,7 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "https://registry.npmmirror.com/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
 
-    "@navfolio/mdx-components": ["@navfolio/mdx-components@github:navfolio/mdx-components#0857ec2", { "dependencies": { "fast-xml-parser": "^5.3.3" }, "peerDependencies": { "astro": "^5.0.0 || ^6.0.0 || ^7.0.0", "lucide-astro": "^0.556.0", "mermaid": "^11.0.0" } }, "navfolio-mdx-components-0857ec2", "sha512-kNh6gmYbHY7aDTVHmlsFGbngb50sC7fkEnnP5pyjYS+6dI8TGZYnZKcfHkbKuC7psXcSFILn7RzrNoD9Grl9tg=="],
+    "@navfolio/mdx-components": ["@navfolio/mdx-components@github:navfolio/mdx-components#dd9fabf", { "dependencies": { "fast-xml-parser": "^5.3.3" }, "peerDependencies": { "astro": "^5.0.0 || ^6.0.0 || ^7.0.0", "lucide-astro": "^0.556.0", "mermaid": "^11.0.0" } }, "navfolio-mdx-components-dd9fabf", "sha512-oReeTsir8fQQxVNgITrak5803J6MPXBi54EWM2QvrTd0D0slwJpfser+Jl1X6cq3rM0toq8ocIxHugGZuP6Hjw=="],
 
     "@navfolio/page-projects": ["@navfolio/page-projects@github:navfolio/page-projects#0ad9922", {}, "navfolio-page-projects-0ad9922", "sha512-8snIFwpGh/RTXsoAut03rSjEhB4BlZ1GzIcsenAE6zk9qJkynhv6aL1viiAtOTUoJ9E1PZ0smaMFRIaqeJfqwA=="],
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@expressive-code/plugin-collapsible-sections": "^0.44.0",
     "@expressive-code/plugin-line-numbers": "^0.44.0",
     "@fontsource/maple-mono": "^5.2.6",
-    "@navfolio/mdx-components": "github:navfolio/mdx-components#0857ec2",
+    "@navfolio/mdx-components": "github:navfolio/mdx-components#dd9fabf",
     "@navfolio/pages": "github:navfolio/pages",
     "@navfolio/plugin-markdown": "github:navfolio/plugin-markdown",
     "@tailwindcss/vite": "^4.3.2",

--- a/scripts/fonts/subset-ui-font.ts
+++ b/scripts/fonts/subset-ui-font.ts
@@ -19,7 +19,15 @@ const subsetFontUrl = getSubsetFontUrl(fontConfig.file);
 const outputFontPath = resolveProjectPath(subsetFontUrl);
 const sourceFontPath = resolveProjectPath(fontConfig.file);
 const subsetFontName = `${fontConfig.zh} UI Subset`;
-const pythonCommands = [join(projectRoot, '.venv', 'bin', 'python'), 'python', 'python3'].filter(
+const isWindows = process.platform === 'win32';
+const venvBinDir = isWindows ? 'Scripts' : 'bin';
+const pythonExe = isWindows ? 'python.exe' : 'python';
+const pyftsubsetExe = isWindows ? 'pyftsubset.exe' : 'pyftsubset';
+const pythonCommands = [
+  join(projectRoot, '.venv', venvBinDir, pythonExe),
+  'python',
+  'python3',
+].filter(
   (command, index, commands) =>
     (index === 0 ? existsSync(command) : true) && commands.indexOf(command) === index,
 );
@@ -210,7 +218,7 @@ function runSubset() {
   ];
 
   const commands = [
-    { command: join(projectRoot, '.venv', 'bin', 'pyftsubset'), args },
+    { command: join(projectRoot, '.venv', venvBinDir, pyftsubsetExe), args },
     ...pythonCommands.map((command) => ({ command, args: ['-m', 'fontTools.subset', ...args] })),
   ];
 

--- a/scripts/fonts/subset-ui-font.ts
+++ b/scripts/fonts/subset-ui-font.ts
@@ -19,6 +19,10 @@ const subsetFontUrl = getSubsetFontUrl(fontConfig.file);
 const outputFontPath = resolveProjectPath(subsetFontUrl);
 const sourceFontPath = resolveProjectPath(fontConfig.file);
 const subsetFontName = `${fontConfig.zh} UI Subset`;
+const pythonCommands = [join(projectRoot, '.venv', 'bin', 'python'), 'python', 'python3'].filter(
+  (command, index, commands) =>
+    (index === 0 ? existsSync(command) : true) && commands.indexOf(command) === index,
+);
 const contentSource = process.env.NAVFOLIO_CONTENT_SOURCE === 'docs' ? 'docs' : 'content';
 const contentRoot = contentSource === 'docs' ? 'src/docs' : 'src/content';
 const projectsModuleEnabled = isPageModuleEnabled(navfolioConfig, 'projects');
@@ -206,8 +210,8 @@ function runSubset() {
   ];
 
   const commands = [
-    { command: 'pyftsubset', args },
-    { command: 'python', args: ['-m', 'fontTools.subset', ...args] },
+    { command: join(projectRoot, '.venv', 'bin', 'pyftsubset'), args },
+    ...pythonCommands.map((command) => ({ command, args: ['-m', 'fontTools.subset', ...args] })),
   ];
 
   for (const { command, args: commandArgs } of commands) {
@@ -220,7 +224,7 @@ function runSubset() {
   }
 
   throw new Error(
-    'Unable to run fonttools. Install it in a virtual environment with `python -m venv .venv && .venv/bin/python -m pip install fonttools brotli`, then add `.venv/bin` to PATH or make `pyftsubset` available on PATH.',
+    'Unable to run fonttools. Install it in the project virtual environment with `python3 -m venv .venv && .venv/bin/python -m pip install fonttools brotli`.',
   );
 }
 
@@ -246,21 +250,17 @@ for record in name_table.names:
 
 font.save(path)
 `;
-  let result = spawnSync('python3', ['-c', script, outputFontPath, subsetFontName], {
-    stdio: 'inherit',
-  });
-
-  if (result.error || result.status !== 0) {
-    result = spawnSync('python', ['-c', script, outputFontPath, subsetFontName], {
+  let result;
+  for (const command of pythonCommands) {
+    result = spawnSync(command, ['-c', script, outputFontPath, subsetFontName], {
       stdio: 'inherit',
     });
+    if (result.status === 0) return;
   }
 
-  if (result.error || result.status !== 0) {
-    throw new Error(
-      `Generated subset font, but failed to sync its internal name to ${subsetFontName}. Ensure Python 3 and fonttools are installed. Error: ${result.error?.message ?? `status ${result.status}`}`,
-    );
-  }
+  throw new Error(
+    `Generated subset font, but failed to sync its internal name to ${subsetFontName}. Ensure Python 3 and fonttools are installed. Error: ${result?.error?.message ?? `status ${result?.status}`}`,
+  );
 }
 
 const chars = new Set<string>();

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -16,9 +16,11 @@ export async function GET(context) {
       description: post.data.description,
       pubDate: post.data.date,
       categories: [
-        ...(post.data.categories ?? []),
-        ...(post.data.tags ?? []),
-        ...(post.data.series ?? []),
+        ...new Set([
+          ...(post.data.categories ?? []),
+          ...(post.data.tags ?? []),
+          ...(post.data.series ?? []),
+        ]),
       ],
       link: `/blog/${post.id}/`,
     })),


### PR DESCRIPTION
## Summary

- Preserve the complete normalized friend list in friend-circle sync output, so FriendCircle shows the total friend count even when a friend has no usable RSS feed.
- Add configurable source-field mapping for friend data:
  - `name-field`
  - `url-field`
  - `avatar-field`
  - `rss-field`
- Support `fieldMap` in MDX friend components, including sources that use `image` rather than `avatar`.
- Keep `Friend circle` as the fallback heading when `title` is omitted or empty; allow non-empty custom titles.
- Deduplicate each RSS item’s categories across categories, tags, and series.
- Update the deployment workflow to pass optional friend-data mapping variables.
- Update `@navfolio/mdx-components` to commit `dd9fabf`.
- Make font subsetting automatically use the project `.venv` Python environment.
- Update docs submodule to the latest documentation revision and use published MDX component imports.

## Validation

- `bun run format:check`
- `bun run docs:build`
- Friend-circle sync tested against the configured remote friendlinks data:
  - 17 friends
  - 128 posts
- Type checks passed for `friend-circle-sync` and `mdx-components`.

## Notes

- The project-local `.venv` is ignored and is used automatically when present for `fonttools`/`brotli`.