### PR TITLE
feat: 集成友链申请 MDX 组件与 GitHub Issue 工作流

### DIFF
--- a/.agents/context/current-progress.md
+++ b/.agents/context/current-progress.md
@@ -19,7 +19,7 @@
 - Markdown preset 对 Expressive Code、callout、columns/timeline、responsive
   tables、Mermaid 和 math 的组合。
 - `mdx-components` 的显式内容 components/runtime helpers，包括友链申请表单、
-  JSON 复制与 GitHub Issue/Issue Form 预填。
+  字段数据复制与 GitHub Issue/Issue Form 预填。
 - 首页 dashboard、Blog archive/category/series/tag、搜索、评论、多语言 UI。
 - starter 与 docs/demo 双内容模式。
 - Friend Circle build-time sync、静态 JSON consumer 和字体子集联动。

--- a/.agents/context/current-progress.md
+++ b/.agents/context/current-progress.md
@@ -1,6 +1,6 @@
 # 当前进度
 
-最后核对：2026-07-25  
+最后核对：2026-07-26
 证据：当前功能分支、当前 manifests、lockfile、source、deploy workflow 与上层
 生态地图。
 
@@ -18,7 +18,8 @@
   routes。
 - Markdown preset 对 Expressive Code、callout、columns/timeline、responsive
   tables、Mermaid 和 math 的组合。
-- `mdx-components` 的显式内容 components/runtime helpers。
+- `mdx-components` 的显式内容 components/runtime helpers，包括友链申请表单、
+  JSON 复制与 GitHub Issue/Issue Form 预填。
 - 首页 dashboard、Blog archive/category/series/tag、搜索、评论、多语言 UI。
 - starter 与 docs/demo 双内容模式。
 - Friend Circle build-time sync、静态 JSON consumer 和字体子集联动。

--- a/bun.lock
+++ b/bun.lock
@@ -284,7 +284,7 @@
 
     "@navfolio/core": ["@navfolio/core@github:navfolio/core#1e7954f", {}, "navfolio-core-1e7954f"],
 
-    "@navfolio/mdx-components": ["@navfolio/mdx-components@github:navfolio/mdx-components#db2a595", { "dependencies": { "fast-xml-parser": "^5.3.3" }, "peerDependencies": { "astro": "^5.0.0 || ^6.0.0 || ^7.0.0", "lucide-astro": "^0.556.0", "mermaid": "^11.0.0" } }, "navfolio-mdx-components-db2a595", "sha512-sqQ4JKyEYGryGWcG02jknZDTSwO6mqarDNEYVOkQZ0J4SNeUSPGaC6rwgK+mU3sgE/Htv+pv8BVvf+khmiqXmA=="],
+    "@navfolio/mdx-components": ["@navfolio/mdx-components@github:navfolio/mdx-components#ec4f96e", { "dependencies": { "fast-xml-parser": "^5.3.3" }, "peerDependencies": { "astro": "^5.0.0 || ^6.0.0 || ^7.0.0", "lucide-astro": "^0.556.0", "mermaid": "^11.0.0" } }, "navfolio-mdx-components-ec4f96e", "sha512-TowpUucYTjIYU3xkd2TLUuIGMbKS7fsaRZBNFTFuHO2fCzo+SHgNTtRhZIMtPLilanxXKFP8C4EnmZtlyfFiwQ=="],
 
     "@navfolio/page-media": ["@navfolio/page-media@github:navfolio/page-media#788affd", { "dependencies": { "@navfolio/mdx-components": "github:navfolio/mdx-components" }, "peerDependencies": { "@navfolio/core": ">=0.1.0", "astro": ">=7.0.0" }, "optionalPeers": ["@navfolio/core"] }, "navfolio-page-media-788affd", "sha512-ZVL5z8KoL2VmMIpzwjHIVC0VIstl4M0l/386s1vDFFVF+9dUeBescN+pUl+lwDn3uM+fDqq6aTaRx1IARlVpfw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -284,7 +284,7 @@
 
     "@navfolio/core": ["@navfolio/core@github:navfolio/core#1e7954f", {}, "navfolio-core-1e7954f"],
 
-    "@navfolio/mdx-components": ["@navfolio/mdx-components@github:navfolio/mdx-components#90444ef", { "dependencies": { "fast-xml-parser": "^5.3.3" }, "peerDependencies": { "astro": "^5.0.0 || ^6.0.0 || ^7.0.0", "lucide-astro": "^0.556.0", "mermaid": "^11.0.0" } }, "navfolio-mdx-components-90444ef", "sha512-KoDG+9HizQKr3T2wNGLfxXZObJayPpNoKus/L4Cv8nQ0adJLmBiH5myj9DeCoLoTPyu+Y/zOK2wTchA/B7DmPA=="],
+    "@navfolio/mdx-components": ["@navfolio/mdx-components@github:navfolio/mdx-components#0905c0d", { "dependencies": { "fast-xml-parser": "^5.3.3" }, "peerDependencies": { "astro": "^5.0.0 || ^6.0.0 || ^7.0.0", "lucide-astro": "^0.556.0", "mermaid": "^11.0.0" } }, "navfolio-mdx-components-0905c0d", "sha512-jZ12by6IeSAq6yYWDnSFN7h7Y7tqsIILqatpwSyLWO6c0AXN5dMrrRwBecnzeUbZWtaadVZmnnhdPCGQLOKTow=="],
 
     "@navfolio/page-media": ["@navfolio/page-media@github:navfolio/page-media#788affd", { "dependencies": { "@navfolio/mdx-components": "github:navfolio/mdx-components" }, "peerDependencies": { "@navfolio/core": ">=0.1.0", "astro": ">=7.0.0" }, "optionalPeers": ["@navfolio/core"] }, "navfolio-page-media-788affd", "sha512-ZVL5z8KoL2VmMIpzwjHIVC0VIstl4M0l/386s1vDFFVF+9dUeBescN+pUl+lwDn3uM+fDqq6aTaRx1IARlVpfw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -284,7 +284,7 @@
 
     "@navfolio/core": ["@navfolio/core@github:navfolio/core#1e7954f", {}, "navfolio-core-1e7954f"],
 
-    "@navfolio/mdx-components": ["@navfolio/mdx-components@github:navfolio/mdx-components#6997956", { "dependencies": { "fast-xml-parser": "^5.3.3" }, "peerDependencies": { "astro": "^5.0.0 || ^6.0.0 || ^7.0.0", "lucide-astro": "^0.556.0", "mermaid": "^11.0.0" } }, "navfolio-mdx-components-6997956"],
+    "@navfolio/mdx-components": ["@navfolio/mdx-components@github:navfolio/mdx-components#841116b", { "dependencies": { "fast-xml-parser": "^5.3.3" }, "peerDependencies": { "astro": "^5.0.0 || ^6.0.0 || ^7.0.0", "lucide-astro": "^0.556.0", "mermaid": "^11.0.0" } }, "navfolio-mdx-components-841116b", "sha512-CZp9V2JybdTcpUwhTSad9/l6Zh69UW39OapJDF7KVPObrbT0QviVUYR8chErMHQL3yIIa8BwcSCeZMKrmuhrlQ=="],
 
     "@navfolio/page-media": ["@navfolio/page-media@github:navfolio/page-media#788affd", { "dependencies": { "@navfolio/mdx-components": "github:navfolio/mdx-components" }, "peerDependencies": { "@navfolio/core": ">=0.1.0", "astro": ">=7.0.0" }, "optionalPeers": ["@navfolio/core"] }, "navfolio-page-media-788affd", "sha512-ZVL5z8KoL2VmMIpzwjHIVC0VIstl4M0l/386s1vDFFVF+9dUeBescN+pUl+lwDn3uM+fDqq6aTaRx1IARlVpfw=="],
 
@@ -1573,6 +1573,8 @@
     "@eslint/eslintrc/minimatch": ["minimatch@3.1.5", "https://registry.npmmirror.com/minimatch/-/minimatch-3.1.5.tgz", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "@humanwhocodes/config-array/minimatch": ["minimatch@3.1.5", "https://registry.npmmirror.com/minimatch/-/minimatch-3.1.5.tgz", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "@navfolio/page-media/@navfolio/mdx-components": ["@navfolio/mdx-components@github:navfolio/mdx-components#6997956", { "dependencies": { "fast-xml-parser": "^5.3.3" }, "peerDependencies": { "astro": "^5.0.0 || ^6.0.0 || ^7.0.0", "lucide-astro": "^0.556.0", "mermaid": "^11.0.0" } }, "navfolio-mdx-components-6997956"],
 
     "@navfolio/plugin-markdown/astro-expressive-code": ["astro-expressive-code@0.44.0", "https://registry.npmmirror.com/astro-expressive-code/-/astro-expressive-code-0.44.0.tgz", { "dependencies": { "rehype-expressive-code": "^0.44.0", "url-extras": "^0.1.0" }, "peerDependencies": { "astro": "^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta || ^7.0.0" } }, "sha512-b1wN/ZvbJprzxlGKIpIes2kQrCY5KRLwys2tWbZAZyjGZcW5ZtgneZnBwzNRiBna9/48d4mQl19KLjcRuhO1hw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -284,7 +284,7 @@
 
     "@navfolio/core": ["@navfolio/core@github:navfolio/core#1e7954f", {}, "navfolio-core-1e7954f"],
 
-    "@navfolio/mdx-components": ["@navfolio/mdx-components@github:navfolio/mdx-components#84b27d6", { "dependencies": { "fast-xml-parser": "^5.3.3" }, "peerDependencies": { "astro": "^5.0.0 || ^6.0.0 || ^7.0.0", "lucide-astro": "^0.556.0", "mermaid": "^11.0.0" } }, "navfolio-mdx-components-84b27d6", "sha512-4K5JYMxFKy1tJHCfI2vzh5kshS5E6MX8PymoiWKjUkQJzYw9WVw2zVxFQb9OYNQchS1CtfUMQEV9tZiQuI47kw=="],
+    "@navfolio/mdx-components": ["@navfolio/mdx-components@github:navfolio/mdx-components#0d01d99", { "dependencies": { "fast-xml-parser": "^5.3.3" }, "peerDependencies": { "astro": "^5.0.0 || ^6.0.0 || ^7.0.0", "lucide-astro": "^0.556.0", "mermaid": "^11.0.0" } }, "navfolio-mdx-components-0d01d99", "sha512-80/V3a33MG1WZ+mTPpDDKoqZacpJPelbrhy2aSG9/FVvM4OkYucjRiavrZ2/HPzQsjXFTLEG3cMIOABGF1aU6g=="],
 
     "@navfolio/page-media": ["@navfolio/page-media@github:navfolio/page-media#788affd", { "dependencies": { "@navfolio/mdx-components": "github:navfolio/mdx-components" }, "peerDependencies": { "@navfolio/core": ">=0.1.0", "astro": ">=7.0.0" }, "optionalPeers": ["@navfolio/core"] }, "navfolio-page-media-788affd", "sha512-ZVL5z8KoL2VmMIpzwjHIVC0VIstl4M0l/386s1vDFFVF+9dUeBescN+pUl+lwDn3uM+fDqq6aTaRx1IARlVpfw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -284,7 +284,7 @@
 
     "@navfolio/core": ["@navfolio/core@github:navfolio/core#1e7954f", {}, "navfolio-core-1e7954f"],
 
-    "@navfolio/mdx-components": ["@navfolio/mdx-components@github:navfolio/mdx-components#841116b", { "dependencies": { "fast-xml-parser": "^5.3.3" }, "peerDependencies": { "astro": "^5.0.0 || ^6.0.0 || ^7.0.0", "lucide-astro": "^0.556.0", "mermaid": "^11.0.0" } }, "navfolio-mdx-components-841116b", "sha512-CZp9V2JybdTcpUwhTSad9/l6Zh69UW39OapJDF7KVPObrbT0QviVUYR8chErMHQL3yIIa8BwcSCeZMKrmuhrlQ=="],
+    "@navfolio/mdx-components": ["@navfolio/mdx-components@github:navfolio/mdx-components#791d42d", { "dependencies": { "fast-xml-parser": "^5.3.3" }, "peerDependencies": { "astro": "^5.0.0 || ^6.0.0 || ^7.0.0", "lucide-astro": "^0.556.0", "mermaid": "^11.0.0" } }, "navfolio-mdx-components-791d42d", "sha512-fpjNFY//A7vPQGxstJIvwLkcmPOaFQ01ipL14ghJOQcucr7jFF2EJUgudYxdISSmzbBGkpbf1JEIDEc2FuAE+w=="],
 
     "@navfolio/page-media": ["@navfolio/page-media@github:navfolio/page-media#788affd", { "dependencies": { "@navfolio/mdx-components": "github:navfolio/mdx-components" }, "peerDependencies": { "@navfolio/core": ">=0.1.0", "astro": ">=7.0.0" }, "optionalPeers": ["@navfolio/core"] }, "navfolio-page-media-788affd", "sha512-ZVL5z8KoL2VmMIpzwjHIVC0VIstl4M0l/386s1vDFFVF+9dUeBescN+pUl+lwDn3uM+fDqq6aTaRx1IARlVpfw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -284,7 +284,7 @@
 
     "@navfolio/core": ["@navfolio/core@github:navfolio/core#1e7954f", {}, "navfolio-core-1e7954f"],
 
-    "@navfolio/mdx-components": ["@navfolio/mdx-components@github:navfolio/mdx-components#a05905c", { "dependencies": { "fast-xml-parser": "^5.3.3" }, "peerDependencies": { "astro": "^5.0.0 || ^6.0.0 || ^7.0.0", "lucide-astro": "^0.556.0", "mermaid": "^11.0.0" } }, "navfolio-mdx-components-a05905c", "sha512-CO8+EG8Shy8mG2CtWi21YWIXjhan7yzxfdcGMtvUNmAprqdDEL2k3JzQ9t0BgNQ4yfnwlR6a78MpekIuWCgQhQ=="],
+    "@navfolio/mdx-components": ["@navfolio/mdx-components@github:navfolio/mdx-components#db2a595", { "dependencies": { "fast-xml-parser": "^5.3.3" }, "peerDependencies": { "astro": "^5.0.0 || ^6.0.0 || ^7.0.0", "lucide-astro": "^0.556.0", "mermaid": "^11.0.0" } }, "navfolio-mdx-components-db2a595", "sha512-sqQ4JKyEYGryGWcG02jknZDTSwO6mqarDNEYVOkQZ0J4SNeUSPGaC6rwgK+mU3sgE/Htv+pv8BVvf+khmiqXmA=="],
 
     "@navfolio/page-media": ["@navfolio/page-media@github:navfolio/page-media#788affd", { "dependencies": { "@navfolio/mdx-components": "github:navfolio/mdx-components" }, "peerDependencies": { "@navfolio/core": ">=0.1.0", "astro": ">=7.0.0" }, "optionalPeers": ["@navfolio/core"] }, "navfolio-page-media-788affd", "sha512-ZVL5z8KoL2VmMIpzwjHIVC0VIstl4M0l/386s1vDFFVF+9dUeBescN+pUl+lwDn3uM+fDqq6aTaRx1IARlVpfw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -284,7 +284,7 @@
 
     "@navfolio/core": ["@navfolio/core@github:navfolio/core#1e7954f", {}, "navfolio-core-1e7954f"],
 
-    "@navfolio/mdx-components": ["@navfolio/mdx-components@github:navfolio/mdx-components#791d42d", { "dependencies": { "fast-xml-parser": "^5.3.3" }, "peerDependencies": { "astro": "^5.0.0 || ^6.0.0 || ^7.0.0", "lucide-astro": "^0.556.0", "mermaid": "^11.0.0" } }, "navfolio-mdx-components-791d42d", "sha512-fpjNFY//A7vPQGxstJIvwLkcmPOaFQ01ipL14ghJOQcucr7jFF2EJUgudYxdISSmzbBGkpbf1JEIDEc2FuAE+w=="],
+    "@navfolio/mdx-components": ["@navfolio/mdx-components@github:navfolio/mdx-components#236579d", { "dependencies": { "fast-xml-parser": "^5.3.3" }, "peerDependencies": { "astro": "^5.0.0 || ^6.0.0 || ^7.0.0", "lucide-astro": "^0.556.0", "mermaid": "^11.0.0" } }, "navfolio-mdx-components-236579d", "sha512-vXTJPU9RWRFdSiNSg7HwNEgAqnPNzFwHgHi+0Gn3E0/5jayrXrb4qgWQ4UiGG4VA89V4sBsP3GLpZKYj5A8+Ag=="],
 
     "@navfolio/page-media": ["@navfolio/page-media@github:navfolio/page-media#788affd", { "dependencies": { "@navfolio/mdx-components": "github:navfolio/mdx-components" }, "peerDependencies": { "@navfolio/core": ">=0.1.0", "astro": ">=7.0.0" }, "optionalPeers": ["@navfolio/core"] }, "navfolio-page-media-788affd", "sha512-ZVL5z8KoL2VmMIpzwjHIVC0VIstl4M0l/386s1vDFFVF+9dUeBescN+pUl+lwDn3uM+fDqq6aTaRx1IARlVpfw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -284,7 +284,7 @@
 
     "@navfolio/core": ["@navfolio/core@github:navfolio/core#1e7954f", {}, "navfolio-core-1e7954f"],
 
-    "@navfolio/mdx-components": ["@navfolio/mdx-components@github:navfolio/mdx-components#0905c0d", { "dependencies": { "fast-xml-parser": "^5.3.3" }, "peerDependencies": { "astro": "^5.0.0 || ^6.0.0 || ^7.0.0", "lucide-astro": "^0.556.0", "mermaid": "^11.0.0" } }, "navfolio-mdx-components-0905c0d", "sha512-jZ12by6IeSAq6yYWDnSFN7h7Y7tqsIILqatpwSyLWO6c0AXN5dMrrRwBecnzeUbZWtaadVZmnnhdPCGQLOKTow=="],
+    "@navfolio/mdx-components": ["@navfolio/mdx-components@github:navfolio/mdx-components#a05905c", { "dependencies": { "fast-xml-parser": "^5.3.3" }, "peerDependencies": { "astro": "^5.0.0 || ^6.0.0 || ^7.0.0", "lucide-astro": "^0.556.0", "mermaid": "^11.0.0" } }, "navfolio-mdx-components-a05905c", "sha512-CO8+EG8Shy8mG2CtWi21YWIXjhan7yzxfdcGMtvUNmAprqdDEL2k3JzQ9t0BgNQ4yfnwlR6a78MpekIuWCgQhQ=="],
 
     "@navfolio/page-media": ["@navfolio/page-media@github:navfolio/page-media#788affd", { "dependencies": { "@navfolio/mdx-components": "github:navfolio/mdx-components" }, "peerDependencies": { "@navfolio/core": ">=0.1.0", "astro": ">=7.0.0" }, "optionalPeers": ["@navfolio/core"] }, "navfolio-page-media-788affd", "sha512-ZVL5z8KoL2VmMIpzwjHIVC0VIstl4M0l/386s1vDFFVF+9dUeBescN+pUl+lwDn3uM+fDqq6aTaRx1IARlVpfw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -284,7 +284,7 @@
 
     "@navfolio/core": ["@navfolio/core@github:navfolio/core#1e7954f", {}, "navfolio-core-1e7954f"],
 
-    "@navfolio/mdx-components": ["@navfolio/mdx-components@github:navfolio/mdx-components#236579d", { "dependencies": { "fast-xml-parser": "^5.3.3" }, "peerDependencies": { "astro": "^5.0.0 || ^6.0.0 || ^7.0.0", "lucide-astro": "^0.556.0", "mermaid": "^11.0.0" } }, "navfolio-mdx-components-236579d", "sha512-vXTJPU9RWRFdSiNSg7HwNEgAqnPNzFwHgHi+0Gn3E0/5jayrXrb4qgWQ4UiGG4VA89V4sBsP3GLpZKYj5A8+Ag=="],
+    "@navfolio/mdx-components": ["@navfolio/mdx-components@github:navfolio/mdx-components#84b27d6", { "dependencies": { "fast-xml-parser": "^5.3.3" }, "peerDependencies": { "astro": "^5.0.0 || ^6.0.0 || ^7.0.0", "lucide-astro": "^0.556.0", "mermaid": "^11.0.0" } }, "navfolio-mdx-components-84b27d6", "sha512-4K5JYMxFKy1tJHCfI2vzh5kshS5E6MX8PymoiWKjUkQJzYw9WVw2zVxFQb9OYNQchS1CtfUMQEV9tZiQuI47kw=="],
 
     "@navfolio/page-media": ["@navfolio/page-media@github:navfolio/page-media#788affd", { "dependencies": { "@navfolio/mdx-components": "github:navfolio/mdx-components" }, "peerDependencies": { "@navfolio/core": ">=0.1.0", "astro": ">=7.0.0" }, "optionalPeers": ["@navfolio/core"] }, "navfolio-page-media-788affd", "sha512-ZVL5z8KoL2VmMIpzwjHIVC0VIstl4M0l/386s1vDFFVF+9dUeBescN+pUl+lwDn3uM+fDqq6aTaRx1IARlVpfw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -284,7 +284,7 @@
 
     "@navfolio/core": ["@navfolio/core@github:navfolio/core#1e7954f", {}, "navfolio-core-1e7954f"],
 
-    "@navfolio/mdx-components": ["@navfolio/mdx-components@github:navfolio/mdx-components#0d01d99", { "dependencies": { "fast-xml-parser": "^5.3.3" }, "peerDependencies": { "astro": "^5.0.0 || ^6.0.0 || ^7.0.0", "lucide-astro": "^0.556.0", "mermaid": "^11.0.0" } }, "navfolio-mdx-components-0d01d99", "sha512-80/V3a33MG1WZ+mTPpDDKoqZacpJPelbrhy2aSG9/FVvM4OkYucjRiavrZ2/HPzQsjXFTLEG3cMIOABGF1aU6g=="],
+    "@navfolio/mdx-components": ["@navfolio/mdx-components@github:navfolio/mdx-components#90444ef", { "dependencies": { "fast-xml-parser": "^5.3.3" }, "peerDependencies": { "astro": "^5.0.0 || ^6.0.0 || ^7.0.0", "lucide-astro": "^0.556.0", "mermaid": "^11.0.0" } }, "navfolio-mdx-components-90444ef", "sha512-KoDG+9HizQKr3T2wNGLfxXZObJayPpNoKus/L4Cv8nQ0adJLmBiH5myj9DeCoLoTPyu+Y/zOK2wTchA/B7DmPA=="],
 
     "@navfolio/page-media": ["@navfolio/page-media@github:navfolio/page-media#788affd", { "dependencies": { "@navfolio/mdx-components": "github:navfolio/mdx-components" }, "peerDependencies": { "@navfolio/core": ">=0.1.0", "astro": ">=7.0.0" }, "optionalPeers": ["@navfolio/core"] }, "navfolio-page-media-788affd", "sha512-ZVL5z8KoL2VmMIpzwjHIVC0VIstl4M0l/386s1vDFFVF+9dUeBescN+pUl+lwDn3uM+fDqq6aTaRx1IARlVpfw=="],
 


### PR DESCRIPTION
## 概要

集成新的 `FriendLinkApplication` MDX 组件，并补充完整的友链申请、GitHub Issue 和 Issue Form 使用文档。

## 主要变更

- 更新 `@navfolio/mdx-components` 依赖，接入友链申请组件。
- 新增友链申请表单，收集：
  - 站点名称
  - 站点地址
  - 头像地址
  - 背景图地址
  - 站点描述
  - RSS / Atom 地址
- `sticky` 不出现在表单中，输出始终固定为 `false`。
- 支持 HTTP/HTTPS URL、必填字段和字段长度校验。
- 使用表单页与数据预览页双页滑动布局，避免窄容器中两栏互相挤压。
- 支持复制不带外层花括号的友链字段块，方便粘贴到评论区申请友链。
- 普通 GitHub Issue 正文仍使用完整 JSON 对象，便于后续自动化解析。
- 支持预填 GitHub Issue Form，并提供：
  - `issueTemplate`
  - `issueTitle`
  - `issueBody`
  - `issueFieldMap`
  - `labels`
  - `assignees`
  - `milestone`
  - `projects`
- 支持 `appearance="seamless"` 和 `appearance="bordered"` 两种嵌入样式。
- 支持通过 `title` 自定义组件标题，默认标题为“申请友链”。
- 更新文档子模块，新增完整组件参数、Issue Form 示例及 GitHub Actions 工作流边界说明。
- 将文档页面标题调整为“从表单生成友链申请”。
- 更新项目进度说明，使“字段数据复制”与组件当前行为保持一致。

## 审查修正

- 修复必填输入框之间无法正常切换焦点的问题。
- 移除数据预览与复制结果最外层的花括号。
- 移除表单页重复的“申请友链信息”标题。
- 将预览区域的无障碍名称从“友链 JSON 预览”调整为“友链数据预览”。
- 明确复制结果是评论申请使用的字段块，而不是独立的标准 JSON。
- 保留普通 Issue 正文中的完整 JSON，避免影响后续 Action 解析。

## 验证

- `@astrojs/check`：0 errors，0 warnings。
- 相关文件 Prettier 检查通过。
- `bun run docs:build` 通过，共生成 75 个页面。
- 浏览器验证通过：
  - 页面标题正确
  - 组件默认标题正确
  - 必填框焦点切换正常
  - 表单与预览页切换正常
  - 复制内容不含外层花括号
  - 复制成功提示正常
  - 浏览器控制台无错误

## 已知的仓库基线问题

- 完整 `bun run format:check` 会在 ESLint 初始化阶段因现有
  `ts-api-utils` / TypeScript 兼容问题报错，与本次改动无关。
- 普通内容模式 `bun run build` 会因当前 `src/content` 中缺少 About、
  Blog 等 starter 内容而失败；文档模式生产构建已正常通过。

## 后续配置

该 PR 只负责组件和文档集成。实际接收申请的目标仓库还需要配置：

1. `.github/ISSUE_TEMPLATE/friend-link.yml`
2. 监听友链申请 Issue 的 GitHub Actions
3. 服务端可信校验、重复检查和友链 JSON 更新逻辑
4. 自动创建分支与 PR 的工作流

建议第一版只自动创建 PR，不自动合并，最终仍由维护者人工审核。